### PR TITLE
update engine config to allow users to add elements to under key extensions

### DIFF
--- a/bin/eslint
+++ b/bin/eslint
@@ -37,6 +37,9 @@ if (process.env.ENGINE_CONFIG) {
   if (engineConfig['exclude_paths']) {
     ignores = engineConfig['exclude_paths'];
   }
+  if (engineConfig['extensions']) {
+    options['extensions'] = engineConfig['extensions'];
+  }
 }
 var cli = new CLIEngine(options);
 var report = cli.executeOnFiles(["/code"]);


### PR DESCRIPTION
@codeclimate/review This PR adds the ability for users to add extensions under an `extensions` key in their eslint engine in .codeclimate.yml file. It keeps `.js` as a default extension if none is provided.