### PR TITLE
Set the check name when there is a fatal error

### DIFF
--- a/bin/eslint
+++ b/bin/eslint
@@ -3,10 +3,18 @@
 var CLIEngine = require("eslint").CLIEngine;
 
 function buildIssueJson(message, path) {
+  // ESLint doesn't emit a ruleId in the
+  // case of a fatal error (such as an invalid
+  // token)
+  var checkName = message.ruleId;
+  if(message.fatal) {
+    checkName = "fatal"
+  }
+
   var issue = {
     type: "issue",
     categories: ["Style"],
-    check_name: message.ruleId,
+    check_name: checkName,
     description: message.message,
     location: {
       path: path,


### PR DESCRIPTION
/cc @codeclimate/review 

In the case of a fatal error, the ruleId is not set: http://eslint.org/docs/developer-guide/nodejs-api.html#linter

> ruleId - the ID of the rule that triggered the messages (or null if fatal is true).

This sets it so that the engine matches the spec