### PR TITLE
Update eslint to our fork

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM mhart/alpine-node
 WORKDIR /usr/src/app
 COPY package.json /usr/src/app/
 
+RUN apk --update add git
+
 RUN npm install
 
 RUN adduser -u 9000 -D app

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url" : "http://github.com/codeclimate/codeclimate-eslint.git"
   },
   "dependencies": {
-    "eslint": "0.24.1",
+    "eslint": "codeclimate/eslint.git#c5457c8",
     "glob": "5.0.14"
   },
   "engine": "node >= 0.12.4"


### PR DESCRIPTION
/cc @codeclimate/review 

[These ESLint commits](https://github.com/codeclimate/eslint/compare/v0.24.1...c5457c8?diff=unified&name=c5457c8) disable requiring of plugins and shared configs, until we can support them in the future.