### PR TITLE
output some perf timing to stderr

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -9,7 +9,7 @@ function runWithTiming(name, fn) {
   var start = new Date(),
       rv = fn(),
       duration = (new Date() - start) / 1000;
-  console.error("eslint.timing." + name + ": " + duration + "s")
+  console.error("eslint.timing." + name + ": " + duration + "s");
   return rv;
 }
 


### PR DESCRIPTION
This is part of https://trello.com/c/93amREzt/751-eslint-performance-issue-discrepency-between-local-and-bbg

@GordonDiggs does this kind of look like what you were thinking?

Output looks like:

```
eslint.timing.engineConfig: 0s
eslint.timing.fileWalk: 0.003s
eslint.timing.cliInit: 0s
eslint.timing.cliRun: 0.001s
eslint.timing.resultsOutput: 0s
```