### PR TITLE
Update to handle config.include_paths or config.exclude_paths.

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -57,10 +57,8 @@ function exclusionBasedFileListBuilder(excludePaths) {
 
     allFiles.forEach(function(file, i, a){
       if(excludePaths.indexOf(file.split("/code/")[1]) < 0) {
-        if(!fs.lstatSync(file).isDirectory()) {
-          var extension = "." + file.split(".").pop();
-
-          if(extensions.indexOf(extension) >= 0) {
+        if(fs.lstatSync(file).isFile()) {
+          if (isFileWithMatchingExtension(file)) {
             analysisFiles.push(file);
           }
         }
@@ -69,11 +67,6 @@ function exclusionBasedFileListBuilder(excludePaths) {
 
     return analysisFiles;
   };
-}
-
-function isFileWithMatchingExtension(file, extensions) {
-  var extension = "." + file.split(".").pop();
-  return (extensions.indexOf(extension) >= 0);
 }
 
 function inclusionBasedFileListBuilder(includePaths) {
@@ -89,22 +82,31 @@ function inclusionBasedFileListBuilder(includePaths) {
           "/code/" + fileOrDirectory + "/**/**"
         );
         filesInThisDirectory.forEach(function(file, j){
-          if(!fs.lstatSync(file).isDirectory()) {
-            if (isFileWithMatchingExtension(file, extensions)) {
-              analysisFiles.push(file);
-            }
+          if (isFileWithMatchingExtension(file, extensions)) {
+            analysisFiles.push(file);
           }
         });
       } else {
         // if not, check for ending in *.js
-        if (isFileWithMatchingExtension(fileOrDirectory, extensions)) {
-          analysisFiles.push("/code/" + fileOrDirectory);
+        var fullPath = "/code/" + fileOrDirectory
+        if (isFileWithMatchingExtension(fullPath, extensions)) {
+          analysisFiles.push(fullPath);
         }
       }
     });
 
     return analysisFiles;
   };
+}
+
+function isFileWithMatchingExtension(file, extensions) {
+  var stats = fs.lstatSync(file);
+  var extension = "." + file.split(".").pop();
+  return (
+    stats.isFile() &&
+    !stats.isSymbolicLink()
+    && extensions.indexOf(extension) >= 0
+  );
 }
 
 var options = {

--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -77,7 +77,7 @@ function isFileWithMatchingExtension(file, extensions) {
 }
 
 function inclusionBasedFileListBuilder(includePaths) {
-  // Uses glob to expand the files and directories in includePaths, filtering 
+  // Uses glob to expand the files and directories in includePaths, filtering
   // down to match the list of desired extensions.
   return function(extensions) {
     var analysisFiles = [];
@@ -104,12 +104,13 @@ function inclusionBasedFileListBuilder(includePaths) {
     });
 
     return analysisFiles;
-  }
+  };
 }
 
 var options = {
   extensions: [".js"], ignore: true, reset: false, useEslintrc: true
 };
+var buildFileList;
 runWithTiming("engineConfig", function () {
   if (fs.existsSync("/config.json")) {
     var engineConfig = JSON.parse(fs.readFileSync("/config.json"));
@@ -121,13 +122,13 @@ runWithTiming("engineConfig", function () {
     if (engineConfig.include_paths) {
       buildFileList = inclusionBasedFileListBuilder(
         engineConfig.include_paths
-      )
+      );
     } else if (engineConfig.exclude_paths) {
-      ignores = engineConfig.exclude_paths;
-      buildFileList = exclusionBasedFileListBuilder(ignores)
+      var ignores = engineConfig.exclude_paths;
+      buildFileList = exclusionBasedFileListBuilder(ignores);
     } else {
       // No includes or excludes, let's try with everything
-      buildFileList = exclusionBasedFileListBuilder([])
+      buildFileList = exclusionBasedFileListBuilder([]);
     }
 
     if (engineConfig.extensions) {
@@ -136,7 +137,7 @@ runWithTiming("engineConfig", function () {
   }
 });
 
-var analysisFiles = runWithTiming("buildFileList", function() { 
+var analysisFiles = runWithTiming("buildFileList", function() {
   return buildFileList(options.extensions);
 });
 var cli = runWithTiming("cliInit", function() { return new CLIEngine(options); }),

--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -45,33 +45,71 @@ function buildIssueJson(message, path) {
   return JSON.stringify(issue);
 }
 
-// Uses glob to traverse code directory and find files to analyze,
-// excluding files passed in with by CLI config, and including only
-// files in the list of desired extensions
-function fileWalk(excludePaths, extensions){
-  var analysisFiles = [];
-  var allFiles = glob.sync("/code/**/**", {});
+function exclusionBasedFileListBuilder(excludePaths) {
+  // Uses glob to traverse code directory and find files to analyze,
+  // excluding files passed in with by CLI config, and including only
+  // files in the list of desired extensions.
+  //
+  // Deprecated style of file expansion, supported for users of the old CLI.
+  return function(extensions) {
+    var analysisFiles = [];
+    var allFiles = glob.sync("/code/**/**", {});
 
-  allFiles.forEach(function(file, i, a){
-    if(excludePaths.indexOf(file.split("/code/")[1]) < 0) {
-      if(!fs.lstatSync(file).isDirectory()) {
-        var extension = "." + file.split(".").pop();
+    allFiles.forEach(function(file, i, a){
+      if(excludePaths.indexOf(file.split("/code/")[1]) < 0) {
+        if(!fs.lstatSync(file).isDirectory()) {
+          var extension = "." + file.split(".").pop();
 
-        if(extensions.indexOf(extension) >= 0) {
-          analysisFiles.push(file);
+          if(extensions.indexOf(extension) >= 0) {
+            analysisFiles.push(file);
+          }
         }
       }
-    }
-  });
+    });
 
-  return analysisFiles;
+    return analysisFiles;
+  };
+}
+
+function isFileWithMatchingExtension(file, extensions) {
+  var extension = "." + file.split(".").pop();
+  return (extensions.indexOf(extension) >= 0);
+}
+
+function inclusionBasedFileListBuilder(includePaths) {
+  // Uses glob to expand the files and directories in includePaths, filtering 
+  // down to match the list of desired extensions.
+  return function(extensions) {
+    var analysisFiles = [];
+
+    includePaths.forEach(function(fileOrDirectory, i) {
+      if ((/\/$/).test(fileOrDirectory)) {
+        // if it ends in a slash, expand and push
+        var filesInThisDirectory = glob.sync(
+          "/code/" + fileOrDirectory + "/**/**"
+        );
+        filesInThisDirectory.forEach(function(file, j){
+          if(!fs.lstatSync(file).isDirectory()) {
+            if (isFileWithMatchingExtension(file, extensions)) {
+              analysisFiles.push(file);
+            }
+          }
+        });
+      } else {
+        // if not, check for ending in *.js
+        if (isFileWithMatchingExtension(fileOrDirectory, extensions)) {
+          analysisFiles.push("/code/" + fileOrDirectory);
+        }
+      }
+    });
+
+    return analysisFiles;
+  }
 }
 
 var options = {
   extensions: [".js"], ignore: true, reset: false, useEslintrc: true
 };
-var ignores = [];
-
 runWithTiming("engineConfig", function () {
   if (fs.existsSync("/config.json")) {
     var engineConfig = JSON.parse(fs.readFileSync("/config.json"));
@@ -80,8 +118,16 @@ runWithTiming("engineConfig", function () {
       options.configFile = "/code/" + engineConfig.config;
     }
 
-    if (engineConfig.exclude_paths) {
+    if (engineConfig.include_paths) {
+      buildFileList = inclusionBasedFileListBuilder(
+        engineConfig.include_paths
+      )
+    } else if (engineConfig.exclude_paths) {
       ignores = engineConfig.exclude_paths;
+      buildFileList = exclusionBasedFileListBuilder(ignores)
+    } else {
+      // No includes or excludes, let's try with everything
+      buildFileList = exclusionBasedFileListBuilder([])
     }
 
     if (engineConfig.extensions) {
@@ -90,8 +136,10 @@ runWithTiming("engineConfig", function () {
   }
 });
 
-var analysisFiles = runWithTiming("fileWalk", function() { return fileWalk(ignores, options.extensions); }),
-    cli = runWithTiming("cliInit", function() { return new CLIEngine(options); }),
+var analysisFiles = runWithTiming("buildFileList", function() { 
+  return buildFileList(options.extensions);
+});
+var cli = runWithTiming("cliInit", function() { return new CLIEngine(options); }),
     report = runWithTiming("cliRun", function() { return cli.executeOnFiles(analysisFiles); });
 
 runWithTiming("resultsOutput",

--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -45,6 +45,16 @@ function buildIssueJson(message, path) {
   return JSON.stringify(issue);
 }
 
+function isFileWithMatchingExtension(file, extensions) {
+  var stats = fs.lstatSync(file);
+  var extension = "." + file.split(".").pop();
+  return (
+    stats.isFile() &&
+    !stats.isSymbolicLink()
+    && extensions.indexOf(extension) >= 0
+  );
+}
+
 function exclusionBasedFileListBuilder(excludePaths) {
   // Uses glob to traverse code directory and find files to analyze,
   // excluding files passed in with by CLI config, and including only
@@ -88,7 +98,7 @@ function inclusionBasedFileListBuilder(includePaths) {
         });
       } else {
         // if not, check for ending in *.js
-        var fullPath = "/code/" + fileOrDirectory
+        var fullPath = "/code/" + fileOrDirectory;
         if (isFileWithMatchingExtension(fullPath, extensions)) {
           analysisFiles.push(fullPath);
         }
@@ -97,16 +107,6 @@ function inclusionBasedFileListBuilder(includePaths) {
 
     return analysisFiles;
   };
-}
-
-function isFileWithMatchingExtension(file, extensions) {
-  var stats = fs.lstatSync(file);
-  var extension = "." + file.split(".").pop();
-  return (
-    stats.isFile() &&
-    !stats.isSymbolicLink()
-    && extensions.indexOf(extension) >= 0
-  );
 }
 
 var options = {


### PR DESCRIPTION
For the time being, engines need to support both the old `include_paths` and the new `exclude_paths` keys in `config.json`. This PR represents that requirement.