### PR TITLE
Warn via STDERR when ESLint is ignoring a path included by `.codeclimate.yml`

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -4,3 +4,5 @@ engines:
 ratings:
   paths:
   - "bin/eslint.js"
+exclude_paths:
+- "node_modules/**"

--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -139,21 +139,26 @@ runWithTiming("engineConfig", function () {
   }
 });
 
+var cli = runWithTiming("cliInit", function() { return new CLIEngine(options); });
+
 var analysisFiles = runWithTiming("buildFileList", function() {
   return buildFileList(options.extensions);
 });
-var cli = runWithTiming("cliInit", function() { return new CLIEngine(options); }),
-    report = runWithTiming("cliRun", function() { return cli.executeOnFiles(analysisFiles); });
+
+var report = runWithTiming("cliRun", function() { return cli.executeOnFiles(analysisFiles); });
 
 runWithTiming("resultsOutput",
   function() {
     report.results.forEach(function(result) {
       var path = result.filePath.replace(/^\/code\//, "");
-
-      result.messages.forEach(function(message) {
-        var issueJson = buildIssueJson(message, path);
-        console.log(issueJson + "\u0000");
-      });
+      if (cli.isPathIgnored(path)) {
+        process.stderr.write("File `" + path + "` ignored because of your .eslintignore file." + "\u0000")
+      } else {
+        result.messages.forEach(function(message) {
+          var issueJson = buildIssueJson(message, path);
+          console.log(issueJson + "\u0000");
+        });
+      }
     });
   }
 );

--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -3,6 +3,8 @@
 var CLIEngine = require("eslint").CLIEngine;
 var fs = require("fs");
 var glob = require("glob");
+var options = { extensions: [".js"], ignore: true, reset: false, useEslintrc: true };
+var cli = runWithTiming("cliInit", function() { return new CLIEngine(options); });
 
 // a wrapper for emitting perf timing
 function runWithTiming(name, fn) {
@@ -119,9 +121,6 @@ function inclusionBasedFileListBuilder(includePaths) {
   };
 }
 
-var options = {
-  extensions: [".js"], ignore: true, reset: false, useEslintrc: true
-};
 var buildFileList;
 runWithTiming("engineConfig", function () {
   if (fs.existsSync("/config.json")) {
@@ -148,8 +147,6 @@ runWithTiming("engineConfig", function () {
     }
   }
 });
-
-var cli = runWithTiming("cliInit", function() { return new CLIEngine(options); });
 
 var analysisFiles = runWithTiming("buildFileList", function() {
   return buildFileList(options.extensions);


### PR DESCRIPTION
ESLint emits a warning when a path, ignored with `.eslintignore`, is passed explicitly for analysis. The issue formatted by this engine doesn't pass validation and causes the engine to error out. This PR delegates to the CLIEngine's `#isPathIgnored` function to determine whether a file path is ignored by `.eslintignore`. If so, we'll write a warning out to STDERR instead of formatting an issue.

@codeclimate/review :mag_right: 