### PR TITLE
Process files in batches, force garbage collection

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/bin/node_gc
+++ b/bin/node_gc
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+/usr/bin/env node --expose-gc "$@"


### PR DESCRIPTION
This may help with our memory consumption issues with the eslint engine in production. I'm forcing GC at intervals.

I ran this locally against the [meteor/meteor](https://github.com/meteor/meteor) repository locally to test. I verified that analysis results were identical with & without batching. I got a rough sense of memory consumption by watching `top` in my docker VM while analysis ran, and the batching seemed to bring down peak memory usage by ~500mb, which is nothing to sneeze at.

Worth mentioning I did try this *without* GC-forcing first, and memory usage was basically unchanged from `master`. I'm not sure whether blame for this lies with node itself or something eslint does internally, but something is a bit strange with the default GC behavior, I think.

cc @codeclimate/review @jp @GordonDiggs 