### PR TITLE
Update location of configuration to match codeclimate.

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -142,8 +142,9 @@ runWithTiming("engineConfig", function () {
       buildFileList = exclusionBasedFileListBuilder([]);
     }
 
-    if (engineConfig.extensions) {
-      options.extensions = engineConfig.extensions;
+    var userConfig = engineConfig.config || {};
+    if (userConfig.extensions) {
+      options.extensions = userConfig.extensions;
     }
   }
 });

--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -126,10 +126,6 @@ runWithTiming("engineConfig", function () {
   if (fs.existsSync("/config.json")) {
     var engineConfig = JSON.parse(fs.readFileSync("/config.json"));
 
-    if (engineConfig.config) {
-      options.configFile = "/code/" + engineConfig.config;
-    }
-
     if (engineConfig.include_paths) {
       buildFileList = inclusionBasedFileListBuilder(
         engineConfig.include_paths
@@ -143,6 +139,10 @@ runWithTiming("engineConfig", function () {
     }
 
     var userConfig = engineConfig.config || {};
+    if (userConfig.config) {
+      options.configFile = "/code/" + userConfig.config;
+    }
+
     if (userConfig.extensions) {
       options.extensions = userConfig.extensions;
     }


### PR DESCRIPTION
As of 0.8.1, the CLI supports this format:
https://github.com/codeclimate/codeclimate/releases/tag/v0.8.1

This fixes specifying extensions to be analyzed by ESLint

@codeclimate/review 