### PR TITLE
Fix “Cannot read property 'indexOf' of undefined” in exclusionBasedFileListBuilder

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -80,7 +80,7 @@ function exclusionBasedFileListBuilder(excludePaths) {
     allFiles.forEach(function(file, i, a){
       if(excludePaths.indexOf(file.split("/code/")[1]) < 0) {
         if(fs.lstatSync(file).isFile()) {
-          if (!isFileIgnoredByLibrary(file) && isFileWithMatchingExtension(file)) {
+          if (!isFileIgnoredByLibrary(file) && isFileWithMatchingExtension(file, extensions)) {
             analysisFiles.push(file);
           }
         }


### PR DESCRIPTION
Hi there - I ran into this error:

```
error: (CC::Analyzer::Engine::EngineFailure) engine eslint failed with status 1 and stderr
eslint.timing.engineConfig: 0s
/usr/src/app/bin/eslint.js:56
    && extensions.indexOf(extension) >= 0
                 ^
TypeError: Cannot read property 'indexOf' of undefined
    at isFileWithMatchingExtension (/usr/src/app/bin/eslint.js:56:18)
    at /usr/src/app/bin/eslint.js:83:48
    at Array.forEach (native)
    at /usr/src/app/bin/eslint.js:80:14
    at /usr/src/app/bin/eslint.js:153:10
    at runWithTiming (/usr/src/app/bin/eslint.js:12:12)
    at Object.<anonymous> (/usr/src/app/bin/eslint.js:152:21)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
```

Presumably exclusionBasedFileListBuilder should be passing `extensions` to `isFileWithMatchingExtension` ?