### PR TITLE
Change directory to /code before running analysis.

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -1,5 +1,7 @@
 #!/usr/src/app/bin/node_gc
 
+process.chdir('/code');
+
 var CLIEngine = require("eslint").CLIEngine;
 var fs = require("fs");
 var glob = require("glob");


### PR DESCRIPTION
Some ESLint functions (namely cli.isPathIgnored) depend on relative
paths, so if we aren't cd'd into /code, it can't find the .eslintignore
file correctly.

@codeclimate/review @mrb 