### PR TITLE
Add content for issues

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -3,6 +3,7 @@
 process.chdir('/code');
 
 var CLIEngine = require("eslint").CLIEngine;
+var docs = require("eslint").docs();
 var fs = require("fs");
 var glob = require("glob");
 var options = { extensions: [".js"], ignore: true, reset: false, useEslintrc: true };
@@ -31,6 +32,7 @@ function buildIssueJson(message, path) {
     categories: ["Style"],
     check_name: checkName,
     description: message.message,
+    content: contentBody(checkName),
     location: {
       path: path,
       positions: {
@@ -47,6 +49,11 @@ function buildIssueJson(message, path) {
     remediation_points: 50000
   };
   return JSON.stringify(issue);
+}
+
+function contentBody(check) {
+  var content = docs[check] || "For more information visit ";
+  return content + "Source: http://eslint.org/docs/rules/\n";
 }
 
 function isFileWithMatchingExtension(file, extensions) {

--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -3,7 +3,7 @@
 process.chdir('/code');
 
 var CLIEngine = require("eslint").CLIEngine;
-var docs = require("eslint").docs();
+var docs = require("eslint").docs;
 var fs = require("fs");
 var glob = require("glob");
 var options = { extensions: [".js"], ignore: true, reset: false, useEslintrc: true };
@@ -52,7 +52,7 @@ function buildIssueJson(message, path) {
 }
 
 function contentBody(check) {
-  var content = docs[check] || "For more information visit ";
+  var content = docs.get(check) || "For more information visit ";
   return content + "Source: http://eslint.org/docs/rules/\n";
 }
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "babel-eslint": "4.1.3",
-    "eslint": "codeclimate/eslint.git#d8eb059",
+    "eslint": "codeclimate/eslint.git#2bbebe6",
     "eslint-plugin-babel": "2.1.1",
     "eslint-plugin-react": "3.5.1",
     "glob": "5.0.14"


### PR DESCRIPTION
Once ESLint is updated to return a `docs` object containing rule
name and doc content:
(PR: https://github.com/codeclimate/eslint/commit/52701b16a36924df16705266992ef4585a36ea25)
we can easily access that data for issue content.

ESLint rule markdown docs here:
https://github.com/eslint/eslint/tree/master/docs/rules

If no doc is found, the content defaults to a suggestion to
read more at Source: http://eslint.org/docs/rules/

cc @codeclimate/review @mrb @jpignata 