### PR TITLE
Add support for Airbnb config

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,13 +3,14 @@
   "version": "0.0.3",
   "description": "eslint",
   "author": "Code Climate",
-  "repository" : {
-    "type" : "git",
-    "url" : "http://github.com/codeclimate/codeclimate-eslint.git"
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/codeclimate/codeclimate-eslint.git"
   },
   "dependencies": {
     "babel-eslint": "4.1.3",
-    "eslint": "codeclimate/eslint.git#65c744a",
+    "eslint": "codeclimate/eslint.git#650b418",
+    "eslint-config-airbnb": "^1.0.0",
     "eslint-plugin-babel": "2.1.1",
     "eslint-plugin-react": "3.6.3",
     "glob": "5.0.14"


### PR DESCRIPTION
This bumps the version of `codeclimate/eslint` which now whitelists
Airbnb. This also adds `eslint-config-airbnb` to `package.json` so
projects that extend the airbnb config will work.