### PR TITLE
update eslint fork to release 1.10.3 of eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "babel-eslint": "4.1.3",
-    "eslint": "codeclimate/eslint.git#9dba1fe",
+    "eslint": "codeclimate/eslint.git#d24d0b451b75cfad304faeb394371096f2c90777",
     "eslint-config-airbnb": "^1.0.0",
     "eslint-plugin-babel": "2.1.1",
     "eslint-plugin-react": "3.6.3",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "babel-eslint": "4.1.3",
-    "eslint": "codeclimate/eslint.git#d24d0b451b75cfad304faeb394371096f2c90777",
+    "eslint": "codeclimate/eslint.git#d24d0b",
     "eslint-config-airbnb": "^1.0.0",
     "eslint-plugin-babel": "2.1.1",
     "eslint-plugin-react": "3.6.3",


### PR DESCRIPTION
Full changes here:
https://github.com/codeclimate/eslint/commit/d24d0b451b75cfad304faeb394371096f2c90777

Original impetus was an error caused by eslint out of date on a [snapshot](https://codeclimate.com/admin/github_repos/564e277d1787d76e57004726/snapshots/5665ca45a759de00010034d3).

Note that in addition to regular updates, this change to our eslint fork required
rewriting the [line that permits airbnb packages](https://github.com/codeclimate/eslint/commit/fd49900c20691ecceaf962f03d9b0929ec0921ce) but no others.

cc @codeclimate/review 