### PR TITLE
update eslint fork to release 1.10.3 of eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "babel-eslint": "4.1.3",
-    "eslint": "codeclimate/eslint.git#9dba1fe",
+    "eslint": "codeclimate/eslint.git#d24d0b",
     "eslint-config-airbnb": "^1.0.0",
     "eslint-plugin-babel": "2.1.1",
     "eslint-plugin-react": "3.6.3",


### PR DESCRIPTION
Full changes here:
https://github.com/codeclimate/eslint/commit/d24d0b451b75cfad304faeb394371096f2c90777

Original impetus was an error caused by eslint out of date on a snapshot.

Note that in addition to regular updates, this change to our eslint fork required
rewriting the line that permits airbnb packages but no others.

cc @codeclimate/review 

same as https://github.com/codeclimate/codeclimate-eslint/pull/50

Wanted to practice cross-repo pulls