### PR TITLE
Don't throw error for unsupported config extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "babel-eslint": "4.1.3",
-    "eslint": "codeclimate/eslint.git#d24d0b",
+    "eslint": "codeclimate/eslint.git#57995c1b630deda4e64eb23804b3c66ef0443dce",
     "eslint-config-airbnb": "^1.0.0",
     "eslint-plugin-babel": "2.1.1",
     "eslint-plugin-react": "3.6.3",


### PR DESCRIPTION
Update ESLint to not throw an error when trying to load node_module
extensions listed in .eslintrc that are unsupported for security reasons:
https://github.com/codeclimate/eslint/commit/57995c1b630deda4e64eb23804b3c66ef0443dce

Fixes: https://codeclimate.com/repos/56746dd23a2003408100006b/builds/1

Similar to this eslint commit:
https://github.com/codeclimate/eslint/commit/fd49900c20691ecceaf962f03d9b0929ec0921ce
which quietly dismisses packages that are unloadable.

@codeclimate/review 

CodeClimate ESLint pull: https://github.com/codeclimate/eslint/pull/7