### PR TITLE
Redirect console.log to console.error

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -11,6 +11,9 @@ var cli = new CLIEngine(options);
 var debug = false;
 var checks = require("../lib/checks");
 
+var stdout = console.log
+console.log = console.error
+
 // a wrapper for emitting perf timing
 function runWithTiming(name, fn) {
   var start = new Date(),
@@ -209,7 +212,7 @@ function analyzeFiles() {
 
         result.messages.forEach(function(message) {
           var issueJson = buildIssueJson(message, path);
-          console.log(issueJson + "\u0000");
+          stdout(issueJson + "\u0000");
         });
       });
     });


### PR DESCRIPTION
This ensures that we are the only ones writing to STDOUT during the run
of the container, and 3rd party `console.log` statements will be
redirected to STDERR.

Proof that it ends up in STDERR:

```
~/cc/codeclimate-eslint (master) 🐖  docker logs 9babbd74e0dd > /dev/null
eslint.timing.engineConfig: 0s
eslint.timing.buildFileList: 1.376s
The react/jsx-quotes rule is deprecated. Please use the jsx-quotes rule instead.
eslint.timing.analyze-batch-0: 0.781s
eslint.timing.report-batch0: 0s
```

@codeclimate/review 