### PR TITLE
Use process.stdout.write instead of console.log and increase batch size

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -194,7 +194,7 @@ var analysisFiles = runWithTiming("buildFileList", function() {
 
 function analyzeFiles() {
   var batchNum = 0
-    , batchSize = 1
+    , batchSize = 10
     , batchFiles
     , batchReport;
 
@@ -214,7 +214,7 @@ function analyzeFiles() {
 
         result.messages.forEach(function(message) {
           var issueJson = buildIssueJson(message, path);
-          stdout(issueJson + "\u0000");
+          process.stdout.write(issueJson + "\u0000");
         });
       });
     });


### PR DESCRIPTION
`console.log` does some extra work to construct the output, and because
it's already a string, we can save some memory by using
`process.stdout.write`. See this issue for more information:
https://github.com/nodejs/node/issues/1741#issuecomment-103827443

This is an attempt to remedy the OOM issues when rendering all the
issues. Increasing the batch size will also help by reducing the number
of GCs.

@codeclimate/review