### PR TITLE
Dockerfile: use tag for base image, add maintainer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,18 @@
-FROM mhart/alpine-node
+FROM mhart/alpine-node:5.4
+MAINTAINER Code Climate <hello@codeclimate.com>
 
 WORKDIR /usr/src/app
 COPY package.json /usr/src/app/
 
-RUN apk --update add git
+RUN apk --update add git && \
+    npm install && \
+    apk del --purge git
 
-RUN npm install
+COPY . /usr/src/app
 
 RUN adduser -u 9000 -D app
 USER app
-
-COPY . /usr/src/app
+VOLUME /code
+WORKDIR /code
 
 CMD ["/usr/src/app/bin/eslint.js"]

--- a/Makefile
+++ b/Makefile
@@ -6,4 +6,4 @@ image:
 	docker build --rm -t $(IMAGE_NAME) .
 
 test: image
-	docker run $(IMAGE_NAME) npm run test
+	docker run --rm --workdir="/usr/src/app" $(IMAGE_NAME) npm run test


### PR DESCRIPTION
Both of these are small best practice things.

1. Use a tag on our base image to reduce chance of random breakage
2. Add maintainer info

:eyes: @codeclimate/review 