### PR TITLE
Default line/column when null

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -51,12 +51,12 @@ function buildIssueJson(message, path) {
       path: path,
       positions: {
         begin: {
-          line: message.line,
-          column: message.column
+          line: message.line || 1,
+          column: message.column || 1
         },
         end: {
-          line: message.line,
-          column: message.column
+          line: message.line || 1,
+          column: message.column || 1
         }
       }
     },


### PR DESCRIPTION
"fatal" issues that eslint reports might not have column/linenumbers.
This is invalid by the engine spec, so we should avoid it.

@codeclimate/review