### PR TITLE
Log the parser we're using at run time

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -16,6 +16,8 @@ var cli = new CLIEngine(options);
 var debug = false;
 var checks = require("../lib/checks");
 
+console.error("ESLint is running with the " + cli.getConfigForFile(null).parser + " parser.");
+
 // a wrapper for emitting perf timing
 function runWithTiming(name, fn) {
   var start = new Date()


### PR DESCRIPTION
Similar to the approach we took for Radon, this is helpful output to
guide users who might need babel toward the info they would need.

cc @codeclimate/review