### PR TITLE
Update eslint-plugin-react

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "eslint": "codeclimate/eslint.git#d24d0b",
     "eslint-config-airbnb": "^5.0.0",
     "eslint-plugin-babel": "2.1.1",
-    "eslint-plugin-react": "3.6.3",
+    "eslint-plugin-react": "3.16.1",
     "glob": "5.0.14"
   },
   "devDependencies": {


### PR DESCRIPTION
This resolves issues with missing rules that are used in the `airbnb` preset.

I'm currently seeing errors like this:

`Definition for rule 'react/no-deprecated' was not found`

This is because airbnb is referencing rules that aren't defined in this version of the react plugin.