### PR TITLE
Error if there is not a valid configuration file

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -15,8 +15,7 @@ var options = { extensions: [".js"], ignore: true, reset: false, useEslintrc: tr
 var cli = new CLIEngine(options);
 var debug = false;
 var checks = require("../lib/checks");
-
-console.error("ESLint is running with the " + cli.getConfigForFile(null).parser + " parser.");
+var validateConfig = require("../lib/validate_config");
 
 // a wrapper for emitting perf timing
 function runWithTiming(name, fn) {
@@ -232,4 +231,12 @@ function analyzeFiles() {
   }
 }
 
-analyzeFiles();
+if (validateConfig(options.configFile)) {
+  console.error("ESLint is running with the " + cli.getConfigForFile(null).parser + " parser.");
+
+  analyzeFiles();
+} else {
+  console.error("No rules are configured. Make sure you have added a config file with rules enabled.");
+  console.error("See our documentation at https://docs.codeclimate.com/docs/eslint for more information.");
+  process.exit(1);
+}

--- a/lib/validate_config.js
+++ b/lib/validate_config.js
@@ -1,0 +1,13 @@
+var CLIEngine = require("eslint").CLIEngine
+  , cli = new CLIEngine()
+  , fs = require("fs");
+
+module.exports = function(configPath) {
+  if (configPath) {
+    return true;
+  } else {
+    var config = cli.getConfigForFile(null);
+
+    return Object.keys(config.rules).length > 0;
+  }
+};

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   },
   "devDependencies": {
     "chai": "^2.1.0",
-    "mocha": "^2.3.4"
+    "mocha": "^2.3.4",
+    "temp": "^0.8.3"
   },
   "scripts": {
     "test": "mocha test"

--- a/test/fixtures/config/.eslintrc.js
+++ b/test/fixtures/config/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  "rules": {
+    "strict": 0
+  }
+};

--- a/test/validate_config_test.js
+++ b/test/validate_config_test.js
@@ -1,0 +1,46 @@
+var expect = require("chai").expect
+  , fs = require("fs")
+  , path = require("path")
+  , temp = require('temp')
+  , validateConfig = require("../lib/validate_config");
+
+temp.track();
+
+describe("validateConfig", function() {
+  it("returns true if given a file", function() {
+    expect(validateConfig("foo.config")).to.eq(true);
+  });
+
+  it("returns false if no files exist", function(done) {
+    temp.mkdir("no-config", function(err, directory) {
+      if (err) throw err;
+
+      process.chdir(directory);
+
+      expect(validateConfig(null)).to.eq(false);
+      done();
+    });
+  });
+
+  it("returns true if an eslintrc exists", function(done) {
+    temp.mkdir("config", function(err, directory) {
+      if (err) throw err;
+
+      process.chdir(directory);
+
+      var configPath = path.join(directory, ".eslintrc.json");
+      var config = {
+        rules: {
+          strict: 0
+        }
+      };
+
+      fs.writeFile(configPath, JSON.stringify(config), function(err) {
+        if (err) throw err;
+
+        expect(validateConfig(null)).to.eq(true);
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
If there is no eslintrc.* file, ESLint's behavior is to do nothing (and
therefore emit no issues). Because this can be confusing, we should fail
hard and show helpful information.

![screen shot 2016-02-12 at 10 54 48 am](https://cloud.githubusercontent.com/assets/245083/13011915/0cb5405a-d177-11e5-9580-646989eebb8c.png)

@codeclimate/review 