### PR TITLE
Behave like --no-eslintrc if custom config is present

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -150,6 +150,7 @@ runWithTiming("engineConfig", function () {
     var userConfig = engineConfig.config || {};
     if (userConfig.config) {
       options.configFile = CODE_DIR + "/" + userConfig.config;
+      options.useEslintrc = false;
     }
 
     if (userConfig.extensions) {


### PR DESCRIPTION
The default behavior of eslint --config is to use that config _in addition to_
any default config (e.g. .eslintrc), not _instead of_. To prevent this, you
have to additionally pass --no-eslintrc.

We find this behavior surprising and prefer setting a custom config to also
imply --no-eslintrc, despite being a behavior difference between the engine and
the underlying tool.

/cc @codeclimate/review

This came out of a CX report. I'm open to opinions if departing from the
default behavior of eslint is actually worthwhile. Another option is to somehow
influence --no-eslintrc via codeclimate.yml.