### PR TITLE
eslint-2: Support standard style ESLint shared config and plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM mhart/alpine-node:5.4
 MAINTAINER Code Climate <hello@codeclimate.com>
 
 WORKDIR /usr/src/app
+COPY npm-shrinkwrap.json /usr/src/app/
 COPY package.json /usr/src/app/
 
 RUN apk --update add git jq && \

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -273,6 +273,11 @@
       "from": "eslint-config-airbnb-base@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-3.0.1.tgz"
     },
+    "eslint-config-standard": {
+      "version": "5.3.1",
+      "from": "eslint-config-standard@5.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-5.3.1.tgz"
+    },
     "eslint-import-resolver-node": {
       "version": "0.2.0",
       "from": "eslint-import-resolver-node@>=0.2.0 <0.3.0",
@@ -293,10 +298,20 @@
       "from": "eslint-plugin-jsx-a11y@1.2.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-1.2.2.tgz"
     },
+    "eslint-plugin-promise": {
+      "version": "1.3.1",
+      "from": "eslint-plugin-promise@1.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-1.3.1.tgz"
+    },
     "eslint-plugin-react": {
       "version": "5.1.1",
       "from": "eslint-plugin-react@5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-5.1.1.tgz"
+    },
+    "eslint-plugin-standard": {
+      "version": "1.3.2",
+      "from": "eslint-plugin-standard@1.3.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-1.3.2.tgz"
     },
     "espree": {
       "version": "3.1.4",

--- a/package.json
+++ b/package.json
@@ -11,10 +11,13 @@
     "babel-eslint": "6.0.4",
     "eslint": "2.10.2",
     "eslint-config-airbnb": "9.0.1",
+    "eslint-config-standard": "5.3.1",
     "eslint-plugin-babel": "3.2.0",
     "eslint-plugin-import": "1.8.1",
     "eslint-plugin-jsx-a11y": "1.2.2",
+    "eslint-plugin-promise": "1.3.1",
     "eslint-plugin-react": "5.1.1",
+    "eslint-plugin-standard": "1.3.2",
     "glob": "7.0.3",
     "meld": "1.3.2"
   },


### PR DESCRIPTION
_This applies a similar update (with different version numbers) from #95 to the `eslint-2` channel._

Standard Style is a commonly adopted style for writing JavaScript. We hope
to support other third-party plugins and shared configurations in the
future without needing to vendor them in but this update removes a blocker for
a bunch of users and I think it's popular enough to warrant pulling into the
engine.

@codeclimate/review 🔎