### PR TITLE
Support for ignore_path in engine config

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -168,6 +168,10 @@ runWithTiming("engineConfig", function () {
       options.extensions = userConfig.extensions;
     }
 
+    if (userConfig.ignore_path) {
+      options.ignorePath = userConfig.ignore_path;
+    }
+
     if (userConfig.debug) {
       debug = true;
     }


### PR DESCRIPTION
Makes it possible to use ignorePath from the CLIEngine. Useful when you
are already ignoring the files you don't want to lint in different file
(.e.g .gitignore).

/cc @codeclimate/review

Extracted from #109.