### PR TITLE
Add eslint-config-airbnb-base as a top-level dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "babel-eslint": "6.1.2",
     "eslint": "2.10.2",
     "eslint-config-airbnb": "9.0.1",
+    "eslint-config-airbnb-base": "^3.0.1",
     "eslint-config-angular": "0.5.0",
     "eslint-config-ember": "^0.3.0",
     "eslint-config-google": "0.6.0",


### PR DESCRIPTION
eslint-config-airbnb-base is a transitive dependency of eslint-config-airbnb, but it is useful in its own right and should be included at the top level such that it has proper support in the eslint engine.

As-is, I can use eslint-config-airbnb-base as an eslint plugin in my project and it works, but this is more than likely due to npm 3's new behavior of installing modules flat instead of nested.

This did not require a change to the npm-shrinkwrap.json. I ran `npm shrinkwrap` after installing this package and it didn't change the shrinkwrap at all.