### PR TITLE
If the project uses Standard, automatically use it

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -177,6 +177,19 @@ runWithTiming("engineConfig", function () {
     }
   }
 
+  // If the project uses Standard, automatically use it.
+  if (!options.configFile && fs.existsSync(CODE_DIR + "/package.json")) {
+    var packageConfig = JSON.parse(fs.readFileSync(CODE_DIR + "/package.json"));
+
+    if ((packageConfig.devDependencies || {}).hasOwnProperty("standard")) {
+      // A module ID can be specified instead of a file path:
+      // http://eslint.org/docs/user-guide/command-line-interface#c---config
+      // http://eslint.org/docs/developer-guide/nodejs-api#cliengine
+      options.configFile = "eslint-config-standard";
+      options.useEslintrc = false;
+    }
+  }
+
   cli = new CLIEngine(options);
 });
 


### PR DESCRIPTION
This change allows to avoid creating ESLint config if the project has `standard` in its `devDependencies`.
In that case, [`eslint-config-standard`](https://github.com/feross/eslint-config-standard) is used instead of `.eslintrc`.
This can be overridden by `config` field of the config of this engine.

Closes #130.