### PR TITLE
Add ember-suave plugin

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -313,6 +313,11 @@
       "from": "eslint-config-ember@>=0.3.0 <0.4.0",
       "resolved": "https://registry.npmjs.org/eslint-config-ember/-/eslint-config-ember-0.3.0.tgz"
     },
+    "eslint-plugin-ember-suave": {
+      "version": "1.0.0",
+      "from": "eslint-plugin-ember-suave@1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-ember-suave/-/eslint-plugin-ember-suave-1.0.0.tgz"
+    },
     "eslint-config-google": {
       "version": "0.6.0",
       "from": "eslint-config-google@>=0.6.0 <0.7.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "eslint-config-airbnb-base": "^7.0.0",
     "eslint-config-angular": "^0.5.0",
     "eslint-config-ember": "^0.3.0",
+    "eslint-plugin-ember-suave": "^1.0.0",
     "eslint-config-google": "^0.6.0",
     "eslint-config-hapi": "^10.0.0",
     "eslint-config-standard": "^6.0.0",


### PR DESCRIPTION
The [original](https://github.com/dockyard/ember-suave) jscs flavor of ember-suave is the [27th most used addon](https://emberobserver.com/addons/ember-suave) in the EmberJS ecosystem. As of a few weeks ago, this configuration has migrated to an eslint-plugin ([eslint-plugin-ember-suave](https://github.com/DockYard/eslint-plugin-ember-suave)) and they plan to make this [the default for the ember suave plugin](https://github.com/DockYard/ember-suave/issues/113).

For the ember community, this is an excellent addition and, for my team, it's required to use codeclimate on our projects.

Merging this PR would resolve #139 