### PR TITLE
Remove intra-issue null characters

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -77,7 +77,7 @@ function buildIssueJson(message, path) {
     issue["fingerprint"] = fingerprint;
   }
 
-  return JSON.stringify(issue);
+  return JSON.stringify(issue).replace(/\u0000/g, "");
 }
 
 function isFileWithMatchingExtension(file, extensions) {


### PR DESCRIPTION
We have an issue reported by a user trying out the eslint-3 channel that
they're getting an unparseable issue error. From the stderr output, it
looks like the unparseable issue is invalid JSON that ends right in the
middle of some content explaining the issue. It looks like we're
splitting on the null character and accidentally cutting an issue in
half. Looking into the `node_modules` folder, there are a few places
where we reference the null character and I think it's possible that
we're inserting it in some places that we don't want to.

@codeclimate/review if this passes the smell test for you, I think the next step is to cherry-pick it to the eslint-2 and eslint-3 channels?