### PR TITLE
Allow ignoring warnings from configuration.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing
+
+## Testing Changes
+Changes made to the engine can be tested locally.
+
+1. Install [the CodeClimate CLI](https://github.com/codeclimate/codeclimate).
+1. Create the image (customizing the `IMAGE_NAME` as needed):
+```bash
+IMAGE_NAME=codeclimate/codeclimate-eslint-test make image
+```
+1. Add the engine to your test `.codeclimate.yml`:
+```bash
+eslint-test:
+  enabled: true
+```
+1. Run analyze via the CLI:
+```bash
+codeclimate analyze --dev
+```

--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -18,6 +18,8 @@ var glob = require("glob");
 var options = { extensions: [".js"], ignore: true, reset: false, useEslintrc: true };
 var cli; // instantiation delayed until after options are (potentially) modified
 var debug = false;
+var ignoreWarnings = false;
+var ESLINT_WARNING_SEVERITY = 1;
 var checks = require("../lib/checks");
 var validateConfig = require("../lib/validate_config");
 var computeFingerprint = require("../lib/compute_fingerprint");
@@ -174,6 +176,10 @@ runWithTiming("engineConfig", function () {
       options.ignorePath = userConfig.ignore_path;
     }
 
+    if (userConfig.ignore_warnings) {
+      ignoreWarnings = true;
+    }
+
     if (userConfig.debug) {
       debug = true;
     }
@@ -209,6 +215,8 @@ function analyzeFiles() {
         var path = result.filePath.replace(/^\/code\//, "");
 
         result.messages.forEach(function(message) {
+          if (ignoreWarnings && message.severity === ESLINT_WARNING_SEVERITY) { return; }
+
           var issueJson = buildIssueJson(message, path);
           process.stdout.write(issueJson + "\u0000\n");
         });


### PR DESCRIPTION
Since `--quiet` is [not a supported configuration](https://github.com/eslint/eslint/issues/1768) for the CLIEngine, I think this is how we'll have to address #142 .

Outstanding Questions:
* [x] manual testing - I could find examples of how to test this locally against a project. are there docs for this or can someone point me in the right direction?

~~* [ ] automated testing - is there any that can be added for this?~~
Integration testing seems out of scope for this change
~~* [ ] docs - where should this config option be documented?~~
docs website needs to be updated