### PR TITLE
Upgrade eslint-config-google to 0.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "eslint-config-airbnb-base": "^7.0.0",
     "eslint-config-angular": "^0.5.0",
     "eslint-config-ember": "^0.3.0",
-    "eslint-config-google": "^0.6.0",
+    "eslint-config-google": "^0.7.1",
     "eslint-config-hapi": "^10.0.0",
     "eslint-config-simplifield": "^4.3.0",
     "eslint-config-standard": "^6.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -338,11 +338,11 @@ es6-weak-map@^2.0.1:
     es6-iterator "2"
     es6-symbol "3"
 
-escape-string-regexp@1.0.2:
+escape-string-regexp@1.0.2, escape-string-regexp@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz#4dbc2fe674e71949caf3fb2695ce7f2dc1d9a8d1"
 
-escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
+escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
@@ -376,11 +376,9 @@ eslint-config-ember@^0.3.0:
     eslint-config-nightmare-mode "^2.3.0"
     object-assign "^4.0.1"
 
-eslint-config-google@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-google/-/eslint-config-google-0.6.0.tgz#c542ec18fb3247983ac16bba31662d01625b763f"
-  dependencies:
-    eslint-config-xo "^0.13.0"
+eslint-config-google@^0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-google/-/eslint-config-google-0.7.1.tgz#5598f8498e9e078420f34b80495b8d959f651fb2"
 
 eslint-config-hapi@^10.0.0:
   version "10.0.0"
@@ -415,10 +413,6 @@ eslint-config-standard-react@^4.0.0:
 eslint-config-standard@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/eslint-config-standard/-/eslint-config-standard-6.2.1.tgz#d3a68aafc7191639e7ee441e7348739026354292"
-
-eslint-config-xo@^0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-xo/-/eslint-config-xo-0.13.0.tgz#f916765432ba67d2fc7a7177b8bcfef3f6eb0564"
 
 eslint-import-resolver-node@^0.2.0:
   version "0.2.3"
@@ -685,7 +679,7 @@ glob@3.2.11:
     inherits "2"
     minimatch "0.3"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.0.6:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.6:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -1149,13 +1143,7 @@ ret@~0.1.10:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.13.tgz#38c2702ece654978941edd8b7dfac6aeeef4067d"
 
-rimraf@^2.2.8:
-  version "2.5.4"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.5.4.tgz#96800093cbf1a0c86bd95b4625467535c29dfa04"
-  dependencies:
-    glob "^7.0.5"
-
-rimraf@~2.2.6:
+rimraf@^2.2.8, rimraf@~2.2.6:
   version "2.2.8"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
 


### PR DESCRIPTION
This replaces https://github.com/codeclimate/codeclimate-eslint/pull/158 -- I borrowed @mike-schultz's commit and ran the `yarn` command to update the `yarn.lock` as well.