### PR TITLE
Add eslint-config-semistandard

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "eslint-config-ember": "^0.3.0",
     "eslint-config-google": "^0.7.1",
     "eslint-config-hapi": "^10.0.0",
+    "eslint-config-semistandard": "^7.0.0",
     "eslint-config-simplifield": "^4.3.0",
     "eslint-config-standard": "^6.2.1",
     "eslint-config-standard-jsx": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -485,6 +485,10 @@ eslint-config-nightmare-mode@^2.3.0:
   dependencies:
     object-assign "^2.0.0"
 
+eslint-config-semistandard@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-semistandard/-/eslint-config-semistandard-7.0.0.tgz#f803493f56a5172f7f59c35ae648360b41f2ff71"
+
 eslint-config-simplifield@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/eslint-config-simplifield/-/eslint-config-simplifield-4.3.0.tgz#ef6913a325d956a8a60ae152b1e4a2d829731859"


### PR DESCRIPTION
`bin/yarn add eslint-config-semistandard`

adds [semistandard](https://github.com/Flet/eslint-config-semistandard) which is the semicolon-appreciating variant of [standard](https://github.com/feross/eslint-config-standard).