### PR TITLE
added eslint-plugin-xogroup as part of codeclimate eslint engine acce…

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "eslint-plugin-promise": "1.3.1",
     "eslint-plugin-react": "3.16.1",
     "eslint-plugin-standard": "1.3.1",
+    "eslint-plugin-xogroup": "^1.0.5",
     "glob": "5.0.14"
   },
   "devDependencies": {


### PR DESCRIPTION
**Context**

As a customer of Code Climate, we would like to extend the `codeclimiate-eslint` engine to accept our custom `eslint-plugin-xogroup` plugin.  We have many JS projects analyzed under the Code Climate toolset.  It is at the point where we need a single source of truth for our rules definition which `eslint` supports.  Since Code Climate does not extensibly allow for custom configs for plugins with `eslint` support, our Code Climate rep informed us we were free to make a PR against this engine to get our plugin added.  Our `eslint-plugin-xogroup` plugin has been NSP scanned.  Please accept that as security compliant.
