### PR TITLE
Fix null-config issue with upgrader

### DIFF
--- a/lib/config_upgrader.js
+++ b/lib/config_upgrader.js
@@ -204,6 +204,10 @@ class ConfigUpgrader {
   };
 
   upgrade(originalConfig) {
+    if (typeof originalConfig === "undefined" || originalConfig === null) {
+      return {};
+    }
+
     let config = merge({}, originalConfig);
 
     this._report = [];

--- a/test/config_upgrater_test.js
+++ b/test/config_upgrater_test.js
@@ -59,6 +59,14 @@ describe("ConfigUpgrader", function() {
 
 
   describe("#upgrade", function() {
+    it("doesn't fail with null config", function(done) {
+      let upgrader = new ConfigUpgrader();
+      expect(function() {
+        upgrader.upgrade(null);
+      }).to.not.throw(TypeError);
+      done();
+    });
+
     describe("ecmaFeatures", function() {
       [
         "arrowFunctions", "binaryLiterals", "blockBindings", "classes",


### PR DESCRIPTION
When upgrader encountered a project that had no `.eslintrc*` but had an unrelated `package.json` that had no ESLint-related options in it an exception was thrown.