### PR TITLE
Fix upgrader with specified ESLint config

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -236,7 +236,7 @@ function analyzeFiles() {
 if (validateConfig(options.configFile)) {
   console.error("ESLint is running with the " + cli.getConfigForFile(null).parser + " parser.");
 
-  for (const line of ConfigUpgrader.upgradeInstructions(analysisFiles, process.cwd())) {
+  for (const line of ConfigUpgrader.upgradeInstructions(options.configFile, analysisFiles, process.cwd())) {
     console.error(line);
   }
 

--- a/lib/config_upgrader.js
+++ b/lib/config_upgrader.js
@@ -245,12 +245,23 @@ class ConfigUpgrader {
     return Array.from(configs);
   }
 
-  static upgradeInstructions(analysisFiles, root) {
-    const reports = this.configs(analysisFiles).map(function(configFile) {
+  static upgradeInstructions(configFile, analysisFiles, root) {
+    let configs;
+    if (configFile) {
+      configs = [configFile];
+    }
+    else {
+      configs = this.configs(analysisFiles);
+    }
+
+    const reports = configs.map(function(configFile) {
       let report = [];
 
       const upgrader = new ConfigUpgrader();
-      const config = new Config({configFile: configFile});
+      const config = new Config({
+        configFile: configFile,
+        cwd: process.cwd()
+      });
       upgrader.upgrade(config.useSpecificConfig);
 
       if (path.extname(configFile) === '') {
@@ -268,6 +279,10 @@ class ConfigUpgrader {
 
       return report;
     });
+
+    if (reports.length === 0) {
+      reports.push([]);
+    }
 
     return reports.reduce(function(a, b) { return a.concat([""]).concat(b); });
   }

--- a/lib/validate_config.js
+++ b/lib/validate_config.js
@@ -1,12 +1,12 @@
 var CLIEngine = require("eslint").CLIEngine
-  , cli = new CLIEngine()
   , fs = require("fs");
 
 module.exports = function(configPath) {
   if (configPath) {
     return true;
   } else {
-    var config = cli.getConfigForFile(null);
+    let cli = new CLIEngine();
+    let config = cli.getConfigForFile(null);
 
     return Object.keys(config.rules).length > 0;
   }

--- a/test/config_upgrater_test.js
+++ b/test/config_upgrater_test.js
@@ -19,7 +19,7 @@ describe("ConfigUpgrader", function() {
 
 
           let report = ConfigUpgrader
-            .upgradeInstructions([directory + '/file.js'], directory);
+            .upgradeInstructions(null, [directory + '/file.js'], directory);
           expect(report).to.deep.eq([
             ".eslintrc appears to be incompatible with ESLint 3.",
             "To upgrade it do the following:\n",
@@ -47,11 +47,33 @@ describe("ConfigUpgrader", function() {
               if (err) { throw err; }
 
               let report = ConfigUpgrader
-                .upgradeInstructions([directory + '/file.js'], directory);
+                .upgradeInstructions(null, [directory + '/file.js'], directory);
               expect(report).to.deep.eq([]);
               done();
             });
           });
+        });
+      });
+    });
+
+    it("uses specific configs", function(done) {
+      temp.mkdir("code", function(err, directory) {
+        if (err) { throw err; }
+
+        process.chdir(directory);
+
+        const configPath = path.join(directory, "codeclimate-eslint");
+        fs.writeFile(configPath, "{}", function(err) {
+          if (err) { throw err; }
+
+          let report = ConfigUpgrader
+            .upgradeInstructions("codeclimate-eslint", [directory + '/file.js'], directory);
+          expect(report).to.deep.eq([
+            "codeclimate-eslint appears to be incompatible with ESLint 3.",
+            "To upgrade it do the following:\n",
+            "* Add .yml or .json to the config file name. Extension-less config file names are deprecated."
+          ]);
+          done();
         });
       });
     });


### PR DESCRIPTION
Upgrader improperly kept detecting ESLint config file when engine had a specific config file specified.

This behaviour resulted in providing upgrade instructions for the wrong config file or in worse case trowing an exception of missing config file.