### PR TITLE
Fix error when there are no config files

### DIFF
--- a/lib/config_upgrader.js
+++ b/lib/config_upgrader.js
@@ -269,7 +269,11 @@ class ConfigUpgrader {
       return report;
     });
 
-    return reports.reduce(function(a, b) { return a.concat([""]).concat(b); });
+    if (reports.length > 0) {
+      return reports.reduce(function(a, b) { return a.concat([""]).concat(b); });
+    } else {
+      return reports;
+    }
   }
 }
 

--- a/test/config_upgrater_test.js
+++ b/test/config_upgrater_test.js
@@ -55,6 +55,19 @@ describe("ConfigUpgrader", function() {
         });
       });
     });
+
+    it("doesn't care if there aren't any configs", function(done) {
+      temp.mkdir("code ", function(err, directory) {
+        if (err) { throw err; }
+
+        process.chdir(directory);
+
+        let report = ConfigUpgrader
+          .upgradeInstructions([directory + '/file.js'], directory);
+        expect(report).to.deep.eq([]);
+        done();
+      });
+    });
   });
 
 


### PR DESCRIPTION
Fixes the following error:

      TypeError: Reduce of empty array with no initial value
          at Array.reduce (native)
          at Function.upgradeInstructions (/usr/src/app/lib/config_upgrader.js:272:20)
          at Object.<anonymous> (/usr/src/app/bin/eslint.js:239:37)
          at Module._compile (module.js:556:32)
          at Object.Module._extensions..js (module.js:565:10)
          at Module.load (module.js:473:32)
          at tryModuleLoad (module.js:432:12)
          at Function.Module._load (module.js:424:3)
          at Module.runMain (module.js:590:10)
          at run (bootstrap_node.js:394:7)

I couldn't find a good initial value to give to `reduce` to obtain the
correct functionality. There's no reason to reduce anyway if there are
no reports.