### PR TITLE
Use stable yarn release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /usr/src/app
 COPY package.json yarn.lock /usr/src/app/
 
 RUN apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg && \
-    echo "deb http://nightly.yarnpkg.com/debian/ nightly main" | tee /etc/apt/sources.list.d/yarn-nightly.list && \
+    echo "deb http://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
     apt-get update && \
     apt-get install -y git jq yarn && \
     yarn install && \


### PR DESCRIPTION
Locally while working with Abby to add a plugin, we noticed some
permissions errors in yarn. Downgrading to the stable release resolves
those errors for me.

We were using the nightly release for a bug fix that has since been
released on stable:
https://github.com/codeclimate/codeclimate-eslint/pull/159#issuecomment-266857865