### PR TITLE
Add eslint-plugin-vue and eslint-plugin-html

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "eslint-plugin-ember-suave": "^1.0.0",
     "eslint-plugin-flowtype": "^2.21.0",
     "eslint-plugin-hapi": "^4.0.0",
+    "eslint-plugin-html": "^2.0.1",
     "eslint-plugin-immutable": "^1.0.0",
     "eslint-plugin-import": "^2.0.1",
     "eslint-plugin-import-order": "^2.1.4",
@@ -48,6 +49,7 @@
     "eslint-plugin-react-native": "^2.2.1",
     "eslint-plugin-security": "^1.2.0",
     "eslint-plugin-standard": "^2.1.1",
+    "eslint-plugin-vue": "^2.0.1",
     "eslint-plugin-xogroup": "^1.1.0",
     "glob": "^7.0.6",
     "meld": "^1.3.2"


### PR DESCRIPTION
Hey,

I tried to build my repository on codeclimate and it seems like that `eslint-plugin-vue` and `eslint-plugin-html` is missing.

I hope this PR will fix the issue.