### PR TITLE
Add support for eslint-plugin-filenames

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "eslint-plugin-angular": "^1.3.1",
     "eslint-plugin-babel": "^3.3.0",
     "eslint-plugin-ember-suave": "^1.0.0",
+    "eslint-plugin-filenames": "^1.1.0",
     "eslint-plugin-flowtype": "^2.21.0",
     "eslint-plugin-hapi": "^4.0.0",
     "eslint-plugin-immutable": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -598,6 +598,14 @@ eslint-plugin-ember-suave@^1.0.0:
   dependencies:
     requireindex "~1.1.0"
 
+eslint-plugin-filenames@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-filenames/-/eslint-plugin-filenames-1.1.0.tgz#bb925218ab25b1aad1c622cfa9cb8f43cc03a4ff"
+  dependencies:
+    lodash.camelcase "4.1.1"
+    lodash.kebabcase "4.0.1"
+    lodash.snakecase "4.0.1"
+
 eslint-plugin-flowtype@^2.21.0:
   version "2.30.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.30.0.tgz#3054a265f9c8afe3046c3d41b72d32a736f9b4ae"
@@ -1140,9 +1148,25 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+lodash.camelcase@4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.1.1.tgz#065b3ff08f0b7662f389934c46a5504c90e0b2d8"
+  dependencies:
+    lodash.capitalize "^4.0.0"
+    lodash.deburr "^4.0.0"
+    lodash.words "^4.0.0"
+
+lodash.capitalize@^4.0.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz#f826c9b4e2a8511d84e3aca29db05e1a4f3b72a9"
+
 lodash.cond@^4.2.0, lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
+
+lodash.deburr@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.deburr/-/lodash.deburr-4.1.0.tgz#ddb1bbb3ef07458c0177ba07de14422cb033ff9b"
 
 lodash.find@4.6.0, lodash.find@^4.2.0:
   version "4.6.0"
@@ -1152,6 +1176,13 @@ lodash.get@^4.3.0, lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
 
+lodash.kebabcase@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.kebabcase/-/lodash.kebabcase-4.0.1.tgz#5e63bc9aa2a5562ff3b97ca7af2f803de1bcb90e"
+  dependencies:
+    lodash.deburr "^4.0.0"
+    lodash.words "^4.0.0"
+
 lodash.memoize@4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
@@ -1159,6 +1190,17 @@ lodash.memoize@4.1.2:
 lodash.pickby@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.pickby/-/lodash.pickby-4.6.0.tgz#7dea21d8c18d7703a27c704c15d3b84a67e33aff"
+
+lodash.snakecase@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.snakecase/-/lodash.snakecase-4.0.1.tgz#bd012e5d2f93f7b58b9303e9a7fbfd5db13d6281"
+  dependencies:
+    lodash.deburr "^4.0.0"
+    lodash.words "^4.0.0"
+
+lodash.words@^4.0.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.words/-/lodash.words-4.2.0.tgz#5ecfeaf8ecf8acaa8e0c8386295f1993c9cf4036"
 
 lodash@^4.0.0, lodash@^4.11.1, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.1:
   version "4.17.2"


### PR DESCRIPTION
The eslint plugin for filenames allows you to verify that users are following a naming convention. For example, npm modules generally follow the kebab-case convention.

At my company, we specifically enforce this in part because there are differences in case-sensitivity across operating systems. Whereas on OSX, filenames are not case-sensitive, they **ARE** on Linux.

This is a plugin with significant backing (for example, [Walmart](https://github.com/walmartlabs/eslint-config-defaults/blob/master/package.json#L22))