### PR TITLE
Do not raise error on unsupported plugins

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -8,7 +8,8 @@ process.chdir(CODE_DIR);
 var stdout = console.log;
 console.log = console.error;
 
-var eslint = require('../lib/eslint-patch')(require('eslint'));
+
+var eslint = require('../lib/eslint-patch')();
 
 var CLIEngine = eslint.CLIEngine;
 var docs = require('../lib/docs')();

--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -11,7 +11,7 @@ console.log = console.error;
 var eslint = require('../lib/eslint-patch')(require('eslint'));
 
 var CLIEngine = eslint.CLIEngine;
-var docs = eslint.docs;
+var docs = require('../lib/docs')();
 var fs = require("fs");
 var glob = require("glob");
 var options = { extensions: [".js"], ignore: true, reset: false, useEslintrc: true };

--- a/lib/docs.js
+++ b/lib/docs.js
@@ -7,13 +7,14 @@
 var fs = require('fs')
   , path = require('path');
 
-//------------------------------------------------------------------------------
-// Privates
-//------------------------------------------------------------------------------
+function Docs() {
 
-var docs = Object.create(null);
+  var docs = Object.create(null);
 
-function load() {
+  function get(ruleId) {
+    return docs[ruleId];
+  }
+
   var docsDir = path.join(__dirname, '/docs/rules');
 
   fs.readdirSync(docsDir).forEach(function(file) {
@@ -22,19 +23,10 @@ function load() {
     // Remove the .md extension from the filename
     docs[file.slice(0, -3)] = content;
   });
+
+  return {
+    get: get
+  };
 }
 
-//------------------------------------------------------------------------------
-// Public Interface
-//------------------------------------------------------------------------------
-
-exports.get = function(ruleId) {
-  return docs[ruleId];
-};
-
-//------------------------------------------------------------------------------
-// Initialization
-//------------------------------------------------------------------------------
-
-// loads existing docs
-load();
+module.exports = Docs;

--- a/lib/empty-plugin.js
+++ b/lib/empty-plugin.js
@@ -3,4 +3,4 @@ module.exports = {
   configs: {
     recommended: {}
   }
-}
+};

--- a/lib/empty-plugin.js
+++ b/lib/empty-plugin.js
@@ -1,0 +1,6 @@
+module.exports = {
+  rules: {},
+  configs: {
+    recommended: {}
+  }
+}

--- a/lib/eslint-patch.js
+++ b/lib/eslint-patch.js
@@ -1,10 +1,11 @@
-'use strict';
+"use strict";
+
 const Plugins = require("eslint/lib/config/plugins");
 
 const Config = require("eslint/lib/config");
-const ConfigUpgrader = require('./config_upgrader');
+const ConfigUpgrader = require("./config_upgrader");
 
-const docs = require('./docs');
+const docs = require("./docs");
 
 module.exports = function patch(eslint) {
 
@@ -26,7 +27,6 @@ module.exports = function patch(eslint) {
     }
   };
 
-
   const originalGetConfig = Config.prototype.getConfig;
   Config.prototype.getConfig = function(filePath) {
     const originalConfig = originalGetConfig.apply(this, [filePath]);
@@ -36,7 +36,6 @@ module.exports = function patch(eslint) {
   };
 
   eslint.docs = docs;
-
 
   return eslint;
 };

--- a/lib/eslint-patch.js
+++ b/lib/eslint-patch.js
@@ -9,19 +9,22 @@ const Config = require("eslint/lib/config");
 const ConfigUpgrader = require("./config_upgrader");
 
 module.exports = function patch() {
-  const skippedPlugins = [];
+
+  const skippedModules = [];
+  function warnModuleNotSupported(name) {
+      if(skippedModules.indexOf(name) < 0) {
+        skippedModules.push(name);
+        console.error(`Module not supported: ${name}`);
+      }
+  }
 
   const resolve = ModuleResolver.prototype.resolve;
   ModuleResolver.prototype.resolve = function(name, path) {
     try {
       return resolve.apply(this, [name, path]);
     } catch(e) {
-      const pluginMatch = name.match(/eslint-plugin-(.+)/);
-      if(pluginMatch && skippedPlugins.indexOf(pluginMatch[1]) >= 0) {
-        return `${__dirname}/empty-plugin.js`;
-      }
-
-      throw e;
+      warnModuleNotSupported(name);
+      return `${__dirname}/empty-plugin.js`;
     }
   };
 
@@ -38,8 +41,7 @@ module.exports = function patch() {
         Plugins.load(name);
 
       } catch(e) {
-        skippedPlugins.push(name);
-        console.error(`Plugin not supported: ${name}`);
+        warnModuleNotSupported(`eslint-plugin-${name}`);
       }
     }
   };

--- a/lib/eslint-patch.js
+++ b/lib/eslint-patch.js
@@ -16,7 +16,7 @@ module.exports = function patch() {
     } catch(e) {
       return `${__dirname}/empty-plugin.js`;
     }
-  }
+  };
 
   Plugins.loadAll = function(pluginNames) {
     const loadedPlugins = Object.keys(Plugins.getAll());

--- a/lib/eslint-patch.js
+++ b/lib/eslint-patch.js
@@ -1,13 +1,22 @@
 "use strict";
 
 const Plugins = require("eslint/lib/config/plugins");
+const ModuleResolver = require("eslint/lib/util/module-resolver");
+
+const ConfigFile = require("eslint/lib/config/config-file");
 
 const Config = require("eslint/lib/config");
 const ConfigUpgrader = require("./config_upgrader");
 
-const docs = require("./docs");
-
-module.exports = function patch(eslint) {
+module.exports = function patch() {
+  const resolve = ModuleResolver.prototype.resolve;
+  ModuleResolver.prototype.resolve = function(name, path) {
+    try {
+      return resolve.apply(this, [name, path]);
+    } catch(e) {
+      return `${__dirname}/empty-plugin.js`;
+    }
+  }
 
   Plugins.loadAll = function(pluginNames) {
     const loadedPlugins = Object.keys(Plugins.getAll());
@@ -35,7 +44,5 @@ module.exports = function patch(eslint) {
     return configUpgrader.upgrade(originalConfig);
   };
 
-  eslint.docs = docs;
-
-  return eslint;
+  return require('eslint');
 };

--- a/lib/eslint-patch.js
+++ b/lib/eslint-patch.js
@@ -31,7 +31,7 @@ module.exports = function patch() {
         Plugins.load(name);
 
       } catch(e) {
-        console.error(`[DEBUG] Plugin ${name} not supported`);
+        console.error(`Plugin not supported: ${name}`);
       }
     }
   };

--- a/lib/eslint-patch.js
+++ b/lib/eslint-patch.js
@@ -1,33 +1,31 @@
 'use strict';
-var meld = require('meld');
-var docs = require('./docs');
-var Config = require("eslint/lib/config");
-var ConfigUpgrader = require('./config_upgrader');
+const Plugins = require("eslint/lib/config/plugins");
 
-var supportedPlugins = ['react', 'babel'];
+const Config = require("eslint/lib/config");
+const ConfigUpgrader = require('./config_upgrader');
 
-module.exports = function patcher(eslint) {
+const docs = require('./docs');
 
-  meld.around(eslint.CLIEngine, 'loadPlugins', function(joinPoint) {
-    var pluginNames = joinPoint.args[0];
-    var filteredPluginNames = pluginNames.filter(function(pluginName) {
-      return supportedPlugins.indexOf(pluginName) >= 0;
-    });
-    return joinPoint.proceed(filteredPluginNames);
-  });
+module.exports = function patch(eslint) {
 
-  meld.around(eslint.CLIEngine, 'addPlugin', function() {
-    return;
-  });
+  Plugins.loadAll = function(pluginNames) {
+    const loadedPlugins = Object.keys(Plugins.getAll());
+    if(loadedPlugins.length > 0) {
+      return;
+    }
 
-  // meld.around(eslint.CLIEngine.Config, 'loadPackage', function(joinPoint) {
-  //   var filePath = joinPoint.args[0];
-  //   if (filePath.match(/^eslint-config-airbnb.*/)) {
-  //     return joinPoint.proceed();
-  //   } else {
-  //     return {};
-  //   }
-  // });
+    for(const index in pluginNames) {
+      const name = pluginNames[index];
+      try {
+
+        Plugins.load(name);
+
+      } catch(e) {
+        console.error(`[DEBUG] Plugin ${name} not supported`);
+      }
+    }
+  };
+
 
   const originalGetConfig = Config.prototype.getConfig;
   Config.prototype.getConfig = function(filePath) {
@@ -38,6 +36,7 @@ module.exports = function patcher(eslint) {
   };
 
   eslint.docs = docs;
+
 
   return eslint;
 };

--- a/lib/eslint-patch.js
+++ b/lib/eslint-patch.js
@@ -9,12 +9,19 @@ const Config = require("eslint/lib/config");
 const ConfigUpgrader = require("./config_upgrader");
 
 module.exports = function patch() {
+  const skippedPlugins = [];
+
   const resolve = ModuleResolver.prototype.resolve;
   ModuleResolver.prototype.resolve = function(name, path) {
     try {
       return resolve.apply(this, [name, path]);
     } catch(e) {
-      return `${__dirname}/empty-plugin.js`;
+      const pluginMatch = name.match(/eslint-plugin-(.+)/);
+      if(pluginMatch && skippedPlugins.indexOf(pluginMatch[1]) >= 0) {
+        return `${__dirname}/empty-plugin.js`;
+      }
+
+      throw e;
     }
   };
 
@@ -31,6 +38,7 @@ module.exports = function patch() {
         Plugins.load(name);
 
       } catch(e) {
+        skippedPlugins.push(name);
         console.error(`Plugin not supported: ${name}`);
       }
     }

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "mocha": "^2.5.3",
+    "sinon": "^1.17.7",
     "temp": "^0.8.3"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -55,8 +55,7 @@
     "eslint-plugin-standard": "^2.1.1",
     "eslint-plugin-vue": "^2.0.1",
     "eslint-plugin-xogroup": "^1.1.0",
-    "glob": "^7.0.6",
-    "meld": "^1.3.2"
+    "glob": "^7.0.6"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/test/eslint-patch_test.js
+++ b/test/eslint-patch_test.js
@@ -1,0 +1,57 @@
+const expect = require("chai").expect;
+const sinon = require("sinon");
+const eslint = require("eslint");
+
+const Plugins = require('eslint/lib/config/plugins');
+const patch = require("../lib/eslint-patch");
+
+describe('eslint-patch', function() {
+  let loadAll;
+
+  before(function() {
+    loadAll = Plugins.loadAll;
+    patch(eslint);
+  });
+
+  after(function() {
+    Plugins.loadAll = loadAll;
+  });
+
+  it('intercept plugins', function() {
+    expect(loadAll).to.not.equal(Plugins.loadAll, 'Plugins.loadAll is not patched');
+  });
+
+  describe('Plugins.loadAll', function() {
+    it('delegates each plugin to be loaded', function () {
+      Plugins.getAll = sinon.stub().returns([]);
+      Plugins.load = sinon.spy();
+
+      Plugins.loadAll([ "jasmine", "mocha"  ]);
+
+      expect(Plugins.load.calledWith("jasmine")).to.be.true;
+      expect(Plugins.load.calledWith("mocha")).to.be.true;
+    });
+
+    it('only load plugins once', function () {
+      Plugins.getAll = sinon.stub().returns([ "node" ]);
+      Plugins.load = sinon.spy();
+
+      Plugins.loadAll([ "node" ]);
+
+      expect(Plugins.load.called).to.be.false;
+    });
+
+    it('does not raise exception for unsupported plugins', function() {
+      Plugins.getAll = sinon.stub().returns([]);
+      Plugins.load = sinon.stub().throws();
+
+      function loadPlugin() {
+        Plugins.loadAll([ 'unsupported-plugin' ]);
+      }
+
+      expect(loadPlugin).to.not.throw();
+    });
+
+  });
+
+});

--- a/test/eslint-patch_test.js
+++ b/test/eslint-patch_test.js
@@ -57,7 +57,7 @@ describe("eslint-patch", function() {
     });
   });
 
-  describe("Avoid error processing plugin loading from extends configuration", function() {
+  describe("loading extends configuration", function() {
     it("patches module resolver", function() {
       const resolve = ModuleResolver.prototype.resolve;
 
@@ -65,9 +65,20 @@ describe("eslint-patch", function() {
       expect(ModuleResolver.prototype.resolve).to.not.eql(resolve);
     });
 
-    it("returns an empty plugin config instead of error", function() {
+    it("returns fake config for skipped plugins", function() {
       eslintPatch();
-      expect(new ModuleResolver().resolve('invalid-plugin')).to.match(/.+empty-plugin.js/);
+      Plugins.loadAll(['invalidplugin']);
+      expect(new ModuleResolver().resolve('eslint-plugin-invalidplugin')).to.match(/.+empty-plugin.js/);
+    });
+
+    it("does not allow bogus configuration on extends", function() {
+      eslintPatch();
+
+      function loadModule() {
+        return new ModuleResolver().resolve('eslint-plugin-bogus');
+      }
+
+      expect(loadModule).to.throw();
     });
   });
 

--- a/test/eslint-patch_test.js
+++ b/test/eslint-patch_test.js
@@ -2,10 +2,10 @@ const expect = require("chai").expect;
 const sinon = require("sinon");
 const eslint = require("eslint");
 
-const Plugins = require('eslint/lib/config/plugins');
+const Plugins = require("eslint/lib/config/plugins");
 const patch = require("../lib/eslint-patch");
 
-describe('eslint-patch', function() {
+describe("eslint-patch", function() {
   let loadAll;
 
   before(function() {
@@ -17,12 +17,12 @@ describe('eslint-patch', function() {
     Plugins.loadAll = loadAll;
   });
 
-  it('intercept plugins', function() {
-    expect(loadAll).to.not.equal(Plugins.loadAll, 'Plugins.loadAll is not patched');
+  it("intercept plugins", function() {
+    expect(loadAll).to.not.equal(Plugins.loadAll, "Plugins.loadAll is not patched");
   });
 
-  describe('Plugins.loadAll', function() {
-    it('delegates each plugin to be loaded', function () {
+  describe("Plugins.loadAll", function() {
+    it("delegates each plugin to be loaded", function () {
       Plugins.getAll = sinon.stub().returns([]);
       Plugins.load = sinon.spy();
 
@@ -32,7 +32,7 @@ describe('eslint-patch', function() {
       expect(Plugins.load.calledWith("mocha")).to.be.true;
     });
 
-    it('only load plugins once', function () {
+    it("only load plugins once", function () {
       Plugins.getAll = sinon.stub().returns([ "node" ]);
       Plugins.load = sinon.spy();
 
@@ -41,12 +41,12 @@ describe('eslint-patch', function() {
       expect(Plugins.load.called).to.be.false;
     });
 
-    it('does not raise exception for unsupported plugins', function() {
+    it("does not raise exception for unsupported plugins", function() {
       Plugins.getAll = sinon.stub().returns([]);
       Plugins.load = sinon.stub().throws();
 
       function loadPlugin() {
-        Plugins.loadAll([ 'unsupported-plugin' ]);
+        Plugins.loadAll([ "unsupported-plugin" ]);
       }
 
       expect(loadPlugin).to.not.throw();

--- a/test/eslint-patch_test.js
+++ b/test/eslint-patch_test.js
@@ -57,7 +57,7 @@ describe("eslint-patch", function() {
     });
   });
 
-  describe("Avoid error processing pluging loading from extends configuration", function() {
+  describe("Avoid error processing plugin loading from extends configuration", function() {
     it("patches module resolver", function() {
       const resolve = ModuleResolver.prototype.resolve;
 

--- a/test/eslint-patch_test.js
+++ b/test/eslint-patch_test.js
@@ -65,20 +65,21 @@ describe("eslint-patch", function() {
       expect(ModuleResolver.prototype.resolve).to.not.eql(resolve);
     });
 
-    it("returns fake config for skipped plugins", function() {
+    it("returns fake config for skipped modules", function() {
       eslintPatch();
       Plugins.loadAll(['invalidplugin']);
       expect(new ModuleResolver().resolve('eslint-plugin-invalidplugin')).to.match(/.+empty-plugin.js/);
     });
 
-    it("does not allow bogus configuration on extends", function() {
+    it("does not warn user repeatedly about not supported modules", function() {
+      console.error = sinon.spy();
       eslintPatch();
 
-      function loadModule() {
-        return new ModuleResolver().resolve('eslint-plugin-bogus');
+      for(var i=0; i<3; i++) {
+        new ModuleResolver().resolve('eslint-plugin-bogus');
       }
 
-      expect(loadModule).to.throw();
+      expect(console.error.callCount).to.eql(1);
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1344,10 +1344,6 @@ lru-cache@2:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.7.3.tgz#6d4524e8b955f95d4f5b58851ce21dd72fb4e952"
 
-meld@^1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/meld/-/meld-1.3.2.tgz#8c3235fb5001b8796f8768818e9e4563b0de8066"
-
 minimatch@0.3:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-0.3.0.tgz#275d8edaac4f1bb3326472089e7949c8394699dd"

--- a/yarn.lock
+++ b/yarn.lock
@@ -978,6 +978,12 @@ foreach@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
 
+formatio@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.1.1.tgz#5ed3ccd636551097383465d996199100e86161e9"
+  dependencies:
+    samsam "~1.1"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -1108,6 +1114,10 @@ inflight@^1.0.4:
 inherits@2, inherits@^2.0.1, inherits@~2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+
+inherits@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
 
 inquirer@^0.12.0:
   version "0.12.0"
@@ -1319,6 +1329,10 @@ lodash.words@^4.0.0:
 lodash@^4.0.0, lodash@^4.11.1, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.1:
   version "4.17.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.2.tgz#34a3055babe04ce42467b607d700072c7ff6bf42"
+
+lolex@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.3.2.tgz#7c3da62ffcb30f0f5a80a2566ca24e45d8a01f31"
 
 loose-envify@^1.0.0:
   version "1.3.0"
@@ -1606,6 +1620,10 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
+samsam@1.1.2, samsam@~1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.1.2.tgz#bec11fdc83a9fda063401210e40176c3024d1567"
+
 semver@5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
@@ -1621,6 +1639,15 @@ shelljs@^0.7.5:
 sigmund@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
+
+sinon@^1.17.7:
+  version "1.17.7"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-1.17.7.tgz#4542a4f49ba0c45c05eb2e9dd9d203e2b8efe0bf"
+  dependencies:
+    formatio "1.1.1"
+    lolex "1.3.2"
+    samsam "1.1.2"
+    util ">=0.10.3 <1"
 
 slash@^1.0.0:
   version "1.0.0"
@@ -1758,6 +1785,12 @@ user-home@^2.0.0:
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+
+"util@>=0.10.3 <1":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
+  dependencies:
+    inherits "2.0.1"
 
 wordwrap@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Fix #192 

Instead of erroring and aborting the execution,
the engine now prints a warning and skip the plugin

Given an .eslintrc.yml:
```yaml
env:
    es6: true
    node: true
parserOptions:
    sourceType: module
plugins:
    - node
    - not_supported
extends:
    - not_valid
    - 'plugin:invalidplugin/recommended'
    - 'eslint:recommended'
    - 'plugin:node/recommended'
rules:
    invalidplugin/rule: 1
    node/exports-style: [error, module.exports]
    indent: [error, 4]
    linebreak-style: [error, unix]
    quotes: [error, double]
    semi: [error, always]
    no-console: off
```
When `CODECLIMATE_DEBUG=true codeclimate analyze` runs
Then the output is like:
```
...
Module not supported: eslint-plugin-not_supported
Module not supported: eslint-plugin-invalidplugin
Module not supported: eslint-config-not_valid
...
Analyzing: app1.js
...

== app1.js (1 issue) ==
1: Definition for rule 'invalidplugin/rule' was not found [eslint]
```