### PR TITLE
Remove file is ignored by `.eslintignore` warnings

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -97,12 +97,7 @@ function isFileWithMatchingExtension(file, extensions) {
 }
 
 function isFileIgnoredByLibrary(file) {
-  var ignored = cli.isPathIgnored(file);
-  if (ignored) {
-    var output = "File `" + file + "` ignored because of your .eslintignore file." + "\n";
-    process.stderr.write(output);
-  }
-  return ignored;
+  return cli.isPathIgnored(file);
 }
 
 function prunePathsWithinSymlinks(paths) {


### PR DESCRIPTION
These warnings generate a lot of noise and obfuscate useful error
messages in errored build output.

We can let ESLint handle ignored file behavior instead of pruning the
paths up front ourselves.