### PR TITLE
Improve docker layer caching and build times

### DIFF
--- a/bin/docs
+++ b/bin/docs
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+version=$1
+printf "Pulling docs from ESlint %s\n" "$version"
+
+git clone https://github.com/eslint/eslint.git /tmp/eslint
+(cd /tmp/eslint && git reset --hard "$version")
+mkdir --parents ./lib/docs
+cp --recursive /tmp/eslint/docs/rules ./lib/docs/rules
+rm --force --recursive /tmp/eslint

--- a/engine.json
+++ b/engine.json
@@ -1,0 +1,13 @@
+{
+  "name": "eslint",
+  "description": "A JavaScript/JSX linting utility.",
+  "maintainer": {
+    "name": "Code Climate",
+    "email": "hello@codeclimate.com"
+  },
+  "languages": [
+    "JavaScript"
+  ],
+  "version": "<generated>",
+  "spec_version": "0.3.1"
+}


### PR DESCRIPTION
Currently, the apt-get package install layer is invalidated anytime we
update npm dependencies. This commit splits package installation and npm
dependency installation into separate steps, which should improve docker
layer caching and speed up build times.

This commit also extracts the inline docs installation into a separate
bin script.