### PR TITLE
Update yarn.lock file automatically for greenkeeper PRs

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -29,6 +29,10 @@ deployment:
         --env GCR_JSON_KEY
         --volume /var/run/docker.sock:/var/run/docker.sock
         codeclimate/patrick push gcr
+  greenkeeper:
+    branch: /greenkeeper\/.*/
+    commands:
+      - yarn run update-yarn-lock-file
 
 notify:
   webhooks:

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
+    "circleci-update-yarn-lock": "^3.1.0",
     "mocha": "^2.5.3",
     "sinon": "^2.0.0",
     "temp": "^0.8.3"
@@ -71,7 +72,8 @@
     "integration": "mocha -gc integration",
     "integration.debug": "mocha -gc debug integration",
     "test": "mocha -gc test",
-    "test.debug": "mocha -gc debug test"
+    "test.debug": "mocha -gc debug test",
+    "update-yarn-lock-file": "update-yarn-lock-file"
   },
   "engine": "node >= 0.12.4"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -292,6 +292,10 @@ chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+circleci-update-yarn-lock@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/circleci-update-yarn-lock/-/circleci-update-yarn-lock-3.1.0.tgz#c9a47539dced47d120f75c8a0c5ed6afe504772f"
+
 circular-json@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.1.tgz#be8b36aefccde8b3ca7aa2d6afc07a37242c0d2d"


### PR DESCRIPTION
Uses a `greenkeeper-*` branch deployment step and the [circleci-update-yarn-lock][] package to update the `yarn.lock` file and push an update to the branch.

Planning on bumping the [two](https://github.com/codeclimate/codeclimate-eslint/pull/219) [open](https://github.com/codeclimate/codeclimate-eslint/pull/220) greenkeeper PRs to test this after merging.

Note: Requires the addition of a deploy key with write access: https://circleci.com/docs/1.0/adding-read-write-deployment-key/

[circleci-update-yarn-lock]: https://github.com/clarkbw/circleci-update-yarn-lock