### PR TITLE
Use bin script to update yarn.lock via CircleCI

### DIFF
--- a/bin/circleci-update-yarn-lock
+++ b/bin/circleci-update-yarn-lock
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+git log --name-status HEAD^..HEAD | grep "fix(package): update" || { echo ">> not an update commit"; exit 0; }
+
+yarn install --no-progress --pure-lockfile
+
+yarn check && { echo ">> yarn check passed, yarn.lock does not need to update"; exit 0; }
+
+yarn install --force --no-progress
+
+name="greenkeeper[bot]"
+email="greenkeeper[bot]@users.noreply.github.com"
+
+git config user.name "$name"
+git config user.email "$email"
+
+git commit --all --message "chore(package): update yarn.lock"
+git push --quiet origin "$CIRCLE_BRANCH"

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,6 @@
 machine:
+  node:
+    version: 6.1.0
   services:
     - docker
 
@@ -32,7 +34,7 @@ deployment:
   greenkeeper:
     branch: /greenkeeper\/.*/
     commands:
-      - yarn run update-yarn-lock-file
+      - bin/circleci-update-yarn-lock
 
 notify:
   webhooks:

--- a/package.json
+++ b/package.json
@@ -72,8 +72,7 @@
     "integration": "mocha -gc integration",
     "integration.debug": "mocha -gc debug integration",
     "test": "mocha -gc test",
-    "test.debug": "mocha -gc debug test",
-    "update-yarn-lock-file": "update-yarn-lock-file"
+    "test.debug": "mocha -gc debug test"
   },
   "engine": "node >= 0.12.4"
 }


### PR DESCRIPTION
This commit updates our CI setup to use local bin script instead of the
[npm module I found][module] to update the yarn.lock file on greenkeeper
package update PRs.

- While cross-origin PRs don't have access to project secrets,
  installing and executing an external module in a step that has push
  access to the repo on GitHub seemed risky
- yarn generate-lock-file does not fully resolve the modules and
  confusingly generates a differently formatted yarn.lock file
  [yarnpkg/yarn#2340][issue]
- Run a full yarn install so that a expected yarn.lock is
  generated/updated

[issue]: https://github.com/yarnpkg/yarn/issues/2340
[module]:https://github.com/clarkbw/circleci-update-yarn-lock