### PR TITLE
Fix boolean config flags behavior

### DIFF
--- a/integration/ignore_warnings/eslintrc.js
+++ b/integration/ignore_warnings/eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  "rules": {
+    "semi": [2, "always"], // 2 - error - always report
+    "indent": [1, 2] // warning - only report when not ignored
+  }
+};

--- a/integration/ignore_warnings/index.js
+++ b/integration/ignore_warnings/index.js
@@ -1,0 +1,3 @@
+function foo() {
+var foo = "bar"
+}

--- a/integration/ignore_warnings_test.js
+++ b/integration/ignore_warnings_test.js
@@ -1,0 +1,108 @@
+const fs = require("fs");
+const sinon = require("sinon");
+const expect = require("chai").expect;
+
+const ESLint = require('../lib/eslint');
+
+describe("ESlint user config for ignore_warnings", function() {
+  let consoleMock = {};
+
+  function executeConfig(configPath) {
+    return ESLint.run(consoleMock, { dir: __dirname, configPath: configPath });
+  }
+
+  function configContentImplicit() {
+    return `
+      {
+        "enabled": true,
+        "config": {
+          "config": "ignore_warnings/eslintrc.js"
+        },
+        "include_paths": [
+          "/usr/src/app/integration/ignore_warnings/index.js"
+        ]
+      }
+    `.trim();
+  }
+
+  function configContentExplicit(ignoreWarnings) {
+    return `
+      {
+        "enabled": true,
+        "config": {
+          "config": "ignore_warnings/eslintrc.js",
+          "ignore_warnings": ${ignoreWarnings}
+        },
+        "include_paths": [
+          "/usr/src/app/integration/ignore_warnings/index.js"
+        ]
+      }
+    `.trim();
+  }
+
+  function buildConfig(configContent) {
+    const tmpdir = fs.mkdtempSync("/tmp/cc-eslint-test-");
+    const configPath = `${tmpdir}/config.json`;
+    fs.writeFileSync(configPath, configContent);
+    return configPath;
+  }
+
+  beforeEach(function() {
+    consoleMock.output = [];
+    consoleMock.log = function(msg) { consoleMock.output.push(msg) };
+    consoleMock.error = sinon.spy();
+  });
+
+  describe("ignore_warnings", function() {
+    it("does emit warnings by default", function() {
+      this.timeout(5000);
+
+      const config = buildConfig(configContentImplicit());
+      executeConfig(config);
+
+      expect(consoleMock.output).to.have.lengthOf(2);
+      expect(consoleMock.output[0]).to.match(/^\{.*/);
+    });
+
+    it("does emit warnings when explicitly false", function() {
+      this.timeout(5000);
+
+      const config = buildConfig(configContentExplicit("false"));
+      executeConfig(config);
+
+      expect(consoleMock.output).to.have.lengthOf(2);
+      expect(consoleMock.output[0]).to.match(/^\{.*/);
+    });
+
+    it("does emit warnings when explicitly stringy false", function() {
+      this.timeout(5000);
+
+      const config = buildConfig(configContentExplicit("\"false\""));
+      executeConfig(config);
+
+      expect(consoleMock.output).to.have.lengthOf(2);
+      expect(consoleMock.output[0]).to.match(/^\{.*/);
+    });
+
+    it("does not emit warnings when explicitly true", function() {
+      this.timeout(5000);
+
+      const config = buildConfig(configContentExplicit("true"));
+      executeConfig(config);
+
+      expect(consoleMock.output).to.have.lengthOf(1);
+      expect(consoleMock.output[0]).to.match(/^\{.*/);
+    });
+
+    it("does not emit warnings when explicitly stringy true", function() {
+      this.timeout(5000);
+
+      const config = buildConfig(configContentExplicit("\"true\""));
+      executeConfig(config);
+
+      expect(consoleMock.output).to.have.lengthOf(1);
+      expect(consoleMock.output[0]).to.match(/^\{.*/);
+    });
+  });
+
+});

--- a/integration/ignore_warnings_test.js
+++ b/integration/ignore_warnings_test.js
@@ -104,5 +104,4 @@ describe("ESlint user config for ignore_warnings", function() {
       expect(consoleMock.output[0]).to.match(/^\{.*/);
     });
   });
-
 });

--- a/lib/engine_config.js
+++ b/lib/engine_config.js
@@ -8,21 +8,30 @@ EngineConfig.prototype.includePaths = function() {
   return this.engineJSON.include_paths;
 };
 
-EngineConfig.prototype.userConfig = function() {
-  return new UserEngineConfig(this.engineJSON.config || {});
+// cc-yaml currently ends up passing bools as stringy equivalents
+function _coerceBool(val) {
+  if (typeof(val) === "string") {
+    return val === "true";
+  } else {
+    return !!val;
+  }
 };
 
 function UserEngineConfig(json) {
   this.json = json;
 };
 
+EngineConfig.prototype.userConfig = function() {
+  return new UserEngineConfig(this.engineJSON.config || {});
+};
+
 UserEngineConfig.prototype.configPath = function() {
   return this.json.config;
-}
+};
 
 UserEngineConfig.prototype.extensions = function() {
   return this.json.extensions;
-}
+};
 
 UserEngineConfig.prototype.debug = function() {
   return _coerceBool(this.json.debug);
@@ -34,15 +43,6 @@ UserEngineConfig.prototype.ignorePath = function() {
 
 UserEngineConfig.prototype.ignoreWarnings = function() {
   return _coerceBool(this.json.ignore_warnings);
-};
-
-// cc-yaml currently ends up passing bools as stringy equivalents
-function _coerceBool(val) {
-  if (typeof(val) === "string") {
-    return val === "true";
-  } else {
-    return !!val;
-  }
 };
 
 module.exports = EngineConfig;

--- a/lib/engine_config.js
+++ b/lib/engine_config.js
@@ -25,7 +25,7 @@ UserEngineConfig.prototype.extensions = function() {
 }
 
 UserEngineConfig.prototype.debug = function() {
-  return !!this.json.debug;
+  return _coerceBool(this.json.debug);
 };
 
 UserEngineConfig.prototype.ignorePath = function() {
@@ -33,7 +33,16 @@ UserEngineConfig.prototype.ignorePath = function() {
 };
 
 UserEngineConfig.prototype.ignoreWarnings = function() {
-  return !!this.json.ignore_warnings;
+  return _coerceBool(this.json.ignore_warnings);
+};
+
+// cc-yaml currently ends up passing bools as stringy equivalents
+function _coerceBool(val) {
+  if (typeof(val) === "string") {
+    return val === "true";
+  } else {
+    return !!val;
+  }
 };
 
 module.exports = EngineConfig;

--- a/lib/engine_config.js
+++ b/lib/engine_config.js
@@ -1,0 +1,39 @@
+var fs = require("fs");
+
+function EngineConfig(path) {
+  this.engineJSON = JSON.parse(fs.readFileSync(path));
+};
+
+EngineConfig.prototype.includePaths = function() {
+  return this.engineJSON.include_paths;
+};
+
+EngineConfig.prototype.userConfig = function() {
+  return new UserEngineConfig(this.engineJSON.config || {});
+};
+
+function UserEngineConfig(json) {
+  this.json = json;
+};
+
+UserEngineConfig.prototype.configPath = function() {
+  return this.json.config;
+}
+
+UserEngineConfig.prototype.extensions = function() {
+  return this.json.extensions;
+}
+
+UserEngineConfig.prototype.debug = function() {
+  return !!this.json.debug;
+};
+
+UserEngineConfig.prototype.ignorePath = function() {
+  return this.json.ignore_path;
+};
+
+UserEngineConfig.prototype.ignoreWarnings = function() {
+  return !!this.json.ignore_warnings;
+};
+
+module.exports = EngineConfig;

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -6,6 +6,7 @@ const glob = require("glob");
 const eslint = require('./eslint-patch')();
 const docs = require('./docs')();
 const BatchSanitizer = require("./batch_sanitizer");
+const EngineConfig = require("./engine_config");
 const checks = require("./checks");
 const validateConfig = require("./validate_config");
 const computeFingerprint = require("./compute_fingerprint");
@@ -148,21 +149,21 @@ function run(console, runOptions) {
   }
 
   function overrideOptions(userConfig) {
-    if (userConfig.config) {
-      options.configFile = codeDir + "/" + userConfig.config;
+    if (userConfig.configPath()) {
+      options.configFile = codeDir + "/" + userConfig.configPath();
       options.useEslintrc = false;
     }
 
-    if (userConfig.extensions) {
-      options.extensions = userConfig.extensions;
+    if (userConfig.extensions()) {
+      options.extensions = userConfig.extensions();
     }
 
-    if (userConfig.ignore_path) {
-      options.ignorePath = userConfig.ignore_path;
+    if (userConfig.ignorePath()) {
+      options.ignorePath = userConfig.ignorePath();
     }
 
-    ignoreWarnings = !!userConfig.ignore_warnings;
-    debug = !!userConfig.debug;
+    ignoreWarnings = userConfig.ignoreWarnings();
+    debug = userConfig.debug();
   }
 
   // No explicit includes, let's try with everything
@@ -170,13 +171,13 @@ function run(console, runOptions) {
 
   runWithTiming("engineConfig", function () {
     if (fs.existsSync(configPath)) {
-      var engineConfig = JSON.parse(fs.readFileSync(configPath));
+      var engineConfig = new EngineConfig(configPath);
 
-      if (engineConfig.include_paths) {
-        buildFileList = inclusionBasedFileListBuilder(engineConfig.include_paths);
+      if (engineConfig.includePaths()) {
+        buildFileList = inclusionBasedFileListBuilder(engineConfig.includePaths());
       }
 
-      overrideOptions(engineConfig.config || {});
+      overrideOptions(engineConfig.userConfig());
     }
 
     cli = new CLIEngine(options);

--- a/test/engine_config_test.js
+++ b/test/engine_config_test.js
@@ -1,4 +1,4 @@
-/* global describe: false, it: false, require: false, process: false */
+/* global describe: false, it: false, require: false, processs: false */
 var expect = require("chai").expect
   , fs = require("fs")
   , path = require("path")
@@ -9,14 +9,15 @@ temp.track();
 
 describe("EngineConfig", function() {
   function withConfig(config, done, cb) {
-    temp.open("engine-config-test", function (err, tmpFh) {
+    temp.mkdir("engine-config-test", function (err, dir) {
       if (err) throw err;
 
-      fs.write(tmpFh.fd, JSON.stringify(config));
-      fs.close(tmpFh.fd, function(err) {
+      process.chdir(dir);
+
+      fs.writeFile("config.json", JSON.stringify(config), function(err) {
         if (err) { throw err; }
 
-        cb(new EngineConfig(tmpFh.path));
+        cb(new EngineConfig("config.json"));
         done();
       });
     });

--- a/test/engine_config_test.js
+++ b/test/engine_config_test.js
@@ -1,0 +1,58 @@
+/* global describe: false, it: false, require: false, process: false */
+var expect = require("chai").expect
+  , fs = require("fs")
+  , path = require("path")
+  , temp = require("temp")
+  , EngineConfig = require("../lib/engine_config");
+
+temp.track();
+
+describe("EngineConfig", function() {
+  function withConfig(config, done, cb) {
+    temp.open("engine-config-test", function (err, tmpFh) {
+      if (err) throw err;
+
+      fs.write(tmpFh.fd, JSON.stringify(config));
+      fs.close(tmpFh.fd, function(err) {
+        if (err) { throw err; }
+
+        cb(new EngineConfig(tmpFh.path));
+        done();
+      });
+    });
+  }
+
+  describe("userConfig", function() {
+    describe("ignoreWarnings", function() {
+      it("is false by default", function(done) {
+        withConfig({}, done, function(engine_config) {
+          expect(engine_config.userConfig().ignoreWarnings()).to.eq(false);
+        });
+      });
+
+      it("is false when specified", function(done) {
+        withConfig({ config: { ignore_warnings: false } }, done, function(engine_config) {
+          expect(engine_config.userConfig().ignoreWarnings()).to.eq(false);
+        });
+      });
+
+      it("is false when specified as string", function(done) {
+        withConfig({ config: { ignore_warnings: "false" } }, done, function(engine_config) {
+          expect(engine_config.userConfig().ignoreWarnings()).to.eq(false);
+        });
+      });
+
+      it("is true when specified", function(done) {
+        withConfig({ config: { ignore_warnings: true } }, done, function(engine_config) {
+          expect(engine_config.userConfig().ignoreWarnings()).to.eq(true);
+        });
+      });
+
+      it("is true when specified as string", function(done) {
+        withConfig({ config: { ignore_warnings: "true" } }, done, function(engine_config) {
+          expect(engine_config.userConfig().ignoreWarnings()).to.eq(true);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Due to some oddness with our `cc-yaml` parser right now, all keys under `config` for an engine are parsed as strings. The engine did not take this into account when inspecting boolean config options `debug` and `ignore_warnings`, which basically meant explicitly specifying *any* value for these flags was always interpreted as `true`, and the only way to get `false` was to not specify the flag at all (since both values default to `false`). (Or you could specify the value as `""` in YAML, since `!!""` is `false` in JS, but that's a dumb hack.)

I started here by writing some red tests & extracting the config behavior out of `lib/eslint.js`, then fixing the bug there to see tests change.

I'll squash up commits before merging.