### PR TITLE
Save engine.json specification file to /, not /usr/src/app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,14 +13,13 @@ RUN apt-get install -y git jq yarn && \
     yarn install && \
     version="v$(npm -j ls eslint | jq -r .dependencies.eslint.version)" && \
     bin/docs "$version" && \
-    cat engine.json | jq ".version = \"$version\"" > /tmp/engine.json && \
+    cat engine.json | jq ".version = \"$version\"" > /engine.json && \
     apt-get purge -y git jq yarn && \
     apt-get autoremove --yes
 
 RUN adduser --uid 9000 --gecos "" --disabled-password app
 COPY . ./
-RUN chown -R app:app ./ && \
-    mv /tmp/engine.json ./
+RUN chown -R app:app ./
 
 USER app
 


### PR DESCRIPTION
This commit updates the final location of the engine specification file
`engine.json` to `/` instead of the engine source code directory
`/usr/src/app`, as required by the Code Climate spec:

https://github.com/codeclimate/spec/blob/master/SPEC.md#engine-specification-file