### PR TITLE
Rule Blocklist update

### DIFF
--- a/lib/rule_blocklist.js
+++ b/lib/rule_blocklist.js
@@ -4,9 +4,9 @@ const Config = require("eslint/lib/config")
   , merge = require("eslint/lib/config/config-ops").merge;
 
 const blocklistedRules = [
+  "import/no-restricted-paths",
   "import/no-unresolved",
-  "import/extensions",
-  "import/no-absolute-path"
+  "node/no-hide-code-modules"
 ];
 
 function filterRules(rules) {

--- a/test/rule_blocklist_test.js
+++ b/test/rule_blocklist_test.js
@@ -42,16 +42,16 @@ describe("ConfigUpgrader", function() {
     describe("rules", function() {
       [
         [
+          {rules: {"import/no-restricted-paths": 1}},
+          {rules: {"import/no-restricted-paths": "off"}}
+        ],
+        [
           {rules: {"import/no-unresolved": [2, "opt1", "opt2"]}},
           {rules: {"import/no-unresolved": "off"}}
         ],
         [
-          {rules: {"import/extensions": 2}},
-          {rules: {"import/extensions": "off"}}
-        ],
-        [
-          {rules: {"import/no-absolute-path": 1}},
-          {rules: {"import/no-absolute-path": "off"}}
+          {rules: {"node/no-hide-code-modules": 2}},
+          {rules: {"node/no-hide-code-modules": "off"}}
         ]
       ].forEach(function(example){
         let originalConfig = example[0];


### PR DESCRIPTION
As per [comment](https://github.com/codeclimate/codeclimate-eslint/pull/231#issuecomment-291585702) in #231, here's update to rule blocklist.

Remove:

* `import/extensions` — it does not fail when can not resolve module, uses  literal value instead
* `import/no-absolute-path` — does not use module resolution, checks whether literal value starts with "/". The mentioned [babel-module issue](https://github.com/codeclimate/codeclimate-eslint/pull/231#issuecomment-291202705) does not appear to be related to this specific rule but a misconfiguration of ESLint.

Add:

* `import/no-restricted-paths` — relies on absolutely resolved module paths
* `node/no-hide-code-modules` — relies on module resolution, also deprecated