### PR TITLE
Fix `make test` and `make integration`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,14 +16,12 @@ image:
 
 integration: image
 	docker run -ti --rm \
-		--volume $(PWD):/code \
-		--workdir /code \
+		--workdir /usr/src/app \
 		$(IMAGE_NAME) npm run $(NPM_INTEGRATION_TARGET)
 
 test: image
 	docker run -ti --rm \
-		--volume $(PWD):/code \
-		--workdir /code \
+		--workdir /usr/src/app \
 		$(IMAGE_NAME) npm run $(NPM_TEST_TARGET)
 
 citest:


### PR DESCRIPTION
We're hitting errors where the `mocha` command is not available. I
believe this is because we were running `yarn` in `/usr/src/app`, and
then trying to run tests in `/code`, where the node_modules aren't
available.

For a sec, I assumed this was related to
https://github.com/codeclimate/codeclimate-eslint/pull/256 but I
confirmed the issue predates that change.