### PR TITLE
Build improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,15 @@ endif
 image:
 	docker build --rm -t $(IMAGE_NAME) .
 
-integration: image
+integration: yarn.lock
 	docker run -ti --rm \
+		-v $(PWD):/usr/src/app \
 		--workdir /usr/src/app \
 		$(IMAGE_NAME) npm run $(NPM_INTEGRATION_TARGET)
 
-test: image
+test: yarn.lock
 	docker run -ti --rm \
+		-v $(PWD):/usr/src/app \
 		--workdir /usr/src/app \
 		$(IMAGE_NAME) npm run $(NPM_TEST_TARGET)
 
@@ -28,3 +30,8 @@ citest:
 	docker run --rm \
 		--workdir /usr/src/app \
 		$(IMAGE_NAME) sh -c "npm run test && npm run integration"
+
+yarn.lock: package.json Dockerfile
+	$(MAKE) image
+	./bin/yarn install
+	touch yarn.lock


### PR DESCRIPTION
The idea is to make sure `yarn.lock` gets updated during development in case `package.json` is manually edited.

The dependencies chain in Makefile seems ok, but this changes might turn the flow a bit convoluted as the result
of `make yarn.lock` generate files which invalidates `docker build` cache.

I think there is also room for improving how we generate `lib/docs` and `engine.json` through `Dockerfile` without having
this process to indirectly dependend on `package.json` (`jq > npm install > package.json`)

Please, let me know if this is worth keeping.