### PR TITLE
Bumps eslint-plugin-react 6.10.0 -> 6.10.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "eslint-plugin-node": "^4.2.1",
     "eslint-plugin-prettier": "^2.0.1",
     "eslint-plugin-promise": "^3.5.0",
-    "eslint-plugin-react": "^6.10.1",
+    "eslint-plugin-react": "^6.10.3",
     "eslint-plugin-react-intl": "^1.0.2",
     "eslint-plugin-react-native": "^2.3.1",
     "eslint-plugin-security": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "eslint-plugin-node": "^4.2.1",
     "eslint-plugin-prettier": "^2.0.1",
     "eslint-plugin-promise": "^3.5.0",
-    "eslint-plugin-react": "^6.10.0",
+    "eslint-plugin-react": "^6.10.1",
     "eslint-plugin-react-intl": "^1.0.2",
     "eslint-plugin-react-native": "^2.3.1",
     "eslint-plugin-security": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -900,7 +900,17 @@ eslint-plugin-react-native@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-native/-/eslint-plugin-react-native-2.3.1.tgz#9ecd1df4f29c23a9a20c415c8e88466ff3724f0e"
 
-eslint-plugin-react@^6.10.0, eslint-plugin-react@^6.9.0:
+eslint-plugin-react@^6.10.1:
+  version "6.10.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-6.10.3.tgz#c5435beb06774e12c7db2f6abaddcbf900cd3f78"
+  dependencies:
+    array.prototype.find "^2.0.1"
+    doctrine "^1.2.2"
+    has "^1.0.1"
+    jsx-ast-utils "^1.3.4"
+    object.assign "^4.0.4"
+
+eslint-plugin-react@^6.9.0:
   version "6.10.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-6.10.0.tgz#9c48b48d101554b5355413e7c64238abde6ef1ef"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -900,7 +900,7 @@ eslint-plugin-react-native@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-native/-/eslint-plugin-react-native-2.3.1.tgz#9ecd1df4f29c23a9a20c415c8e88466ff3724f0e"
 
-eslint-plugin-react@^6.10.1:
+eslint-plugin-react@^6.10.3:
   version "6.10.3"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-6.10.3.tgz#c5435beb06774e12c7db2f6abaddcbf900cd3f78"
   dependencies:


### PR DESCRIPTION
In particular this incorporates the `Fix jsx-indent crash` bug fix.
https://github.com/yannickcr/eslint-plugin-react/releases/tag/v6.10.1