### PR TITLE
Revert jsx-a11y upgrade to 5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "eslint-plugin-jquery": "^1.1.1",
     "eslint-plugin-jsdoc": "^3.0.0",
     "eslint-plugin-json": "^1.2.0",
-    "eslint-plugin-jsx-a11y": "^5.0.0",
+    "eslint-plugin-jsx-a11y": "^4.0.0",
     "eslint-plugin-lodash": "^2.3.5",
     "eslint-plugin-lodash-fp": "^2.1.3",
     "eslint-plugin-meteor": "^4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -57,9 +57,9 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-aria-query@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-0.5.0.tgz#85e3152cd8cc5bab18dbed61cd9c4fce54fa79c3"
+aria-query@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-0.3.0.tgz#cb8a9984e2862711c83c80ade5b8f5ca0de2b467"
   dependencies:
     ast-types-flow "0.0.7"
 
@@ -95,12 +95,6 @@ ast-types-flow@0.0.7:
 ast-types@0.9.8:
   version "0.9.8"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.8.tgz#6cb6a40beba31f49f20928e28439fc14a3dab078"
-
-axobject-query@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-0.1.0.tgz#62f59dbc59c9f9242759ca349960e7a2fe3c36c0"
-  dependencies:
-    ast-types-flow "0.0.7"
 
 babel-code-frame@6.22.0, babel-code-frame@^6.16.0, babel-code-frame@^6.20.0, babel-code-frame@^6.22.0:
   version "6.22.0"
@@ -759,13 +753,7 @@ eslint-plugin-hapi@^4.0.0:
     hapi-scope-start "2.x.x"
     no-arrowception "1.x.x"
 
-eslint-plugin-html@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-html/-/eslint-plugin-html-2.0.1.tgz#3a829510e82522f1e2e44d55d7661a176121fce1"
-  dependencies:
-    htmlparser2 "^3.8.2"
-
-eslint-plugin-html@^2.0.3:
+eslint-plugin-html@^2.0.0, eslint-plugin-html@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/eslint-plugin-html/-/eslint-plugin-html-2.0.3.tgz#7c89883ab0c85fa5d28b666a14a4e906aa90b897"
   dependencies:
@@ -833,16 +821,16 @@ eslint-plugin-json@^1.2.0:
   dependencies:
     jshint "^2.8.0"
 
-eslint-plugin-jsx-a11y@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-5.0.0.tgz#88c1d26b2d145ef077ab3d130be15243ac06a877"
+eslint-plugin-jsx-a11y@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-4.0.0.tgz#779bb0fe7b08da564a422624911de10061e048ee"
   dependencies:
-    aria-query "^0.5.0"
+    aria-query "^0.3.0"
     ast-types-flow "0.0.7"
-    axobject-query "^0.1.0"
     damerau-levenshtein "^1.0.0"
     emoji-regex "^6.1.0"
-    jsx-ast-utils "^1.4.0"
+    jsx-ast-utils "^1.0.0"
+    object-assign "^4.0.1"
 
 eslint-plugin-lodash-fp@^2.1.3:
   version "2.1.3"
@@ -1386,7 +1374,7 @@ jsonpointer@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-4.0.0.tgz#6661e161d2fc445f19f98430231343722e1fcbd5"
 
-jsx-ast-utils@^1.3.4, jsx-ast-utils@^1.4.0:
+jsx-ast-utils@^1.0.0, jsx-ast-utils@^1.3.4, jsx-ast-utils@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-1.4.0.tgz#5afe38868f56bc8cc7aeaef0100ba8c75bd12591"
   dependencies:


### PR DESCRIPTION
Addresses https://github.com/codeclimate/codeclimate-eslint/issues/271

The greenkeeper jsx-a11y upgrade to 5.0.0 is breaking compatibility with base configs such as airbnb. That is because they incorporated [breaking changes](https://github.com/evcohen/eslint-plugin-jsx-a11y/releases/tag/v5.0.0) such as rule renames.

I'm not sure why this was even allowed as an upgrade, given running `bin/yarn` on master outputs unmet dependency warnings:
```
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
warning "eslint-config-airbnb@14.1.0" has incorrect peer dependency "eslint-plugin-jsx-a11y@^3.0.2 || ^4.0.0".
warning "eslint-config-react-app@0.6.2" has incorrect peer dependency "eslint-plugin-jsx-a11y@^2.0.0 || ^3.0.0 || ^4.0.0".
[4/4] Building fresh packages...
Done in 12.83s.
```

We should hold off on the 5.0.0 upgrade until the base packages are upgraded to support 5.0.0. The previous version (4.0.0) has no dependency warnings.

```
Chriss-MacBook-Pro:codeclimate-eslint chrishulton$ bin/yarn upgrade eslint-plugin-jsx-a11y@^4.0.0
yarn upgrade v0.21.3
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
success Saved 3 new dependencies.
├─ aria-query@0.3.0
├─ eslint-plugin-jsx-a11y@4.0.0
└─ jsx-ast-utils@1.4.0
Done in 10.26s.
```


