### PR TITLE
Add support for eslint-plugin-ember

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "eslint-plugin-angular": "^2.0.0",
     "eslint-plugin-babel": "^4.1.1",
     "eslint-plugin-ejs": "^0.0.2",
+    "eslint-plugin-ember": "^3.6.1",
     "eslint-plugin-ember-suave": "^1.0.0",
     "eslint-plugin-filenames": "^1.1.0",
     "eslint-plugin-flowtype": "^2.34.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -498,6 +498,10 @@ domutils@1.5:
     dom-serializer "0"
     domelementtype "1"
 
+ember-rfc176-data@^0.2.2:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.2.4.tgz#f6c5e52ffb14cf66c9fed5bd70fbe68fc91982e9"
+
 emoji-regex@^6.1.0:
   version "6.1.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.1.3.tgz#ec79a3969b02d2ecf2b72254279bf99bc7a83932"
@@ -729,6 +733,14 @@ eslint-plugin-ember-suave@^1.0.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-ember-suave/-/eslint-plugin-ember-suave-1.0.0.tgz#ea7d232a126562dcd8b1ee3aa2700ac3b626e514"
   dependencies:
     requireindex "~1.1.0"
+
+eslint-plugin-ember@^3.6.1:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-ember/-/eslint-plugin-ember-3.6.1.tgz#edbc8dde4a964e84c6ba2c0aa49c90aadf69a719"
+  dependencies:
+    ember-rfc176-data "^0.2.2"
+    requireindex "^1.1.0"
+    snake-case "^2.1.0"
 
 eslint-plugin-filenames@^1.1.0:
   version "1.1.0"
@@ -1506,6 +1518,10 @@ loose-envify@^1.0.0:
   dependencies:
     js-tokens "^2.0.0"
 
+lower-case@^1.1.1:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-1.1.4.tgz#9a2cabd1b9e8e0ae993a4bf7d5875c39c42e8eac"
+
 minimatch@^3.0.2, minimatch@^3.0.3, minimatch@~3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"
@@ -1565,6 +1581,12 @@ natural-compare@^1.4.0:
 no-arrowception@1.x.x:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/no-arrowception/-/no-arrowception-1.0.0.tgz#5bf3e95eb9c41b57384a805333daa3b734ee327a"
+
+no-case@^2.2.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/no-case/-/no-case-2.3.1.tgz#7aeba1c73a52184265554b7dc03baf720df80081"
+  dependencies:
+    lower-case "^1.1.1"
 
 number-is-nan@^1.0.0:
   version "1.0.1"
@@ -1778,7 +1800,7 @@ require-uncached@^1.0.2:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
 
-requireindex@~1.1.0:
+requireindex@^1.1.0, requireindex@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.1.0.tgz#e5404b81557ef75db6e49c5a72004893fe03e162"
 
@@ -1861,6 +1883,12 @@ slash@^1.0.0:
 slice-ansi@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
+
+snake-case@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/snake-case/-/snake-case-2.1.0.tgz#41bdb1b73f30ec66a04d4e2cad1b76387d4d6d9f"
+  dependencies:
+    no-case "^2.2.0"
 
 source-map-support@^0.4.2:
   version "0.4.6"


### PR DESCRIPTION
eslint-plugin-ember can be found here: https://github.com/netguru/eslint-plugin-ember

I have tested this plugin by following the directions at https://github.com/codeclimate/codeclimate-eslint/blob/master/CONTRIBUTING.md and found it to work with our .codeclimate.yml configuration.

FYI: I discussed adding this in a zendesk customer support conversation with @davehenton.

I appreciate you looking in to adding this plugin as it will fix our codeclimate build. Temporarily, I have added a specific .eslintrc-codeclimate.js for codeclimate to use that does not reference this plugin, but we are now having issues with keeping the extra configuration in sync and have found that specifying a specific eslintrc bypasses the automatic use of per-directory eslintrc files, which causes false positives codeclimate. Anyway, it would be really great for our team to get this merged :)