### PR TITLE
Add support for eslint-plugin-sort-class-members

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "eslint-plugin-react-intl": "^1.0.2",
     "eslint-plugin-react-native": "^2.3.1",
     "eslint-plugin-security": "^1.3.0",
+    "eslint-plugin-sort-class-members": "^1.1.1",
     "eslint-plugin-standard": "^3.0.0",
     "eslint-plugin-vue": "^2.0.1",
     "eslint-plugin-xogroup": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -928,6 +928,10 @@ eslint-plugin-security@^1.3.0:
   dependencies:
     safe-regex "^1.1.0"
 
+eslint-plugin-sort-class-members@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-sort-class-members/-/eslint-plugin-sort-class-members-1.1.1.tgz#dedbb30054fced1a55a9d443bb2b842a0cfc95f1"
+
 eslint-plugin-standard@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-standard/-/eslint-plugin-standard-3.0.0.tgz#9164df33e78f2eebf3da252ac6cb70de9376ab19"


### PR DESCRIPTION
[eslint-plugin-sort-class-members](https://github.com/bryanrsmith/eslint-plugin-sort-class-members) add a rule to  enforce consistent ES6 class member order.