### PR TITLE
Add eslint-plugin-ember

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "eslint-plugin-babel": "^4.1.1",
     "eslint-plugin-ejs": "^0.0.2",
     "eslint-plugin-ember-suave": "^1.0.0",
+    "eslint-plugin-ember": "^3.6.2",
     "eslint-plugin-filenames": "^1.1.0",
     "eslint-plugin-flowtype": "^2.34.0",
     "eslint-plugin-hapi": "^4.0.0",


### PR DESCRIPTION
Ember Brazil developers need the official plugin available in their configurations.

`eslint-plugin-ember`

https://github.com/ember-cli/eslint-plugin-ember

```js
module.exports = {
  globals: {
    server: true,
  },
  root: true,
  parserOptions: {
    ecmaVersion: 2017,
    sourceType: 'module'
  },
  extends: [
    'plugin:ember/recommended',
  ],
  env: {
    browser: true
  },
  rules: {
  }
};

```