### PR TITLE
eslint-4/README: Fix link back to master

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ support.
 
 For stable ESLint 3 please see [`master`][] branch.
 
-[`channels/eslint-4`]: https://github.com/codeclimate/codeclimate-eslint/tree/master
-
+[`master`]: https://github.com/codeclimate/codeclimate-eslint/tree/master
 
 ### Installation
 


### PR DESCRIPTION
This PR is a simple typographical change that adjusts the README to match the syntax used in `master`, but to point back to `master`.