### PR TITLE
Bump eslint-plugin-react to 7.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "eslint-plugin-no-unsafe-innerhtml": "^1.0.16",
     "eslint-plugin-node": "^5.1.1",
     "eslint-plugin-prettier": "2.3.1",
-    "eslint-plugin-react": "^7.4.0",
+    "eslint-plugin-react": "^7.5.1",
     "eslint-plugin-react-native": "^3.1.0",
     "eslint-plugin-security": "1.4.0",
     "eslint-plugin-sorting": "^0.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1284,6 +1284,15 @@ eslint-plugin-react@^7.4.0:
     jsx-ast-utils "^2.0.0"
     prop-types "^15.5.10"
 
+eslint-plugin-react@^7.5.1:
+  version "7.5.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.5.1.tgz#52e56e8d80c810de158859ef07b880d2f56ee30b"
+  dependencies:
+    doctrine "^2.0.0"
+    has "^1.0.1"
+    jsx-ast-utils "^2.0.0"
+    prop-types "^15.6.0"
+
 eslint-plugin-scanjs-rules@>=0.1.4:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-scanjs-rules/-/eslint-plugin-scanjs-rules-0.2.1.tgz#a37403fde845df41277e03e5c2073f055d47942d"
@@ -1301,7 +1310,7 @@ eslint-plugin-sorting@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-sorting/-/eslint-plugin-sorting-0.3.0.tgz#acf43ca88f34b42ba3d0f6bf0e0c50485a20f60d"
 
-eslint-plugin-xogroup@*:
+eslint-plugin-xogroup@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-xogroup/-/eslint-plugin-xogroup-2.1.0.tgz#11bc2b069b85b2ffa31376552b44a3f773b8e657"
 
@@ -2516,7 +2525,7 @@ promised-io@*:
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/promised-io/-/promised-io-0.3.5.tgz#4ad217bb3658bcaae9946b17a8668ecd851e1356"
 
-prop-types@^15.5.10:
+prop-types@^15.5.10, prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:


### PR DESCRIPTION
Bumps eslint-react-plugin to 7.5.1:

- In response to: https://github.com/codeclimate/codeclimate-eslint/issues/355