### PR TITLE
Add eslint-plugin-es5

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "eslint-plugin-ejs": "^0.0.2",
     "eslint-plugin-ember": "^4.5.0",
     "eslint-plugin-ember-suave": "^1.0.0",
+    "eslint-plugin-es5": "^1.2.0",
     "eslint-plugin-eslint-comments": "^1.0.1",
     "eslint-plugin-filenames": "^1.1.0",
     "eslint-plugin-flowtype": "^2.34.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1140,6 +1140,10 @@ eslint-plugin-ember@^4.5.0:
     require-folder-tree "^1.4.5"
     snake-case "^2.1.0"
 
+eslint-plugin-es5@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-es5/-/eslint-plugin-es5-1.2.0.tgz#22e1e7d5681b3a2f2588247bc9ca51dbfee6f6e9"
+
 eslint-plugin-eslint-comments@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-1.0.1.tgz#9d4056308a1a6c3681c2ef420ae7f243372930d7"


### PR DESCRIPTION
Adds the es5 plugin to address #370. Needed so linter can be configured to error on ES2015 features accidentally getting into ES5 files.