### PR TITLE
add eslint-plugin-scanjs-rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "eslint-plugin-ramda": "^2.4.0",
     "eslint-plugin-react": "^7.5.1",
     "eslint-plugin-react-native": "^3.1.0",
+    "eslint-plugin-scanjs-rules": "^0.2.1",
     "eslint-plugin-security": "1.4.0",
     "eslint-plugin-sorting": "^0.3.0",
     "eslint-plugin-standard": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1301,7 +1301,7 @@ eslint-plugin-react@^7.4.0, eslint-plugin-react@^7.5.1:
     jsx-ast-utils "^2.0.0"
     prop-types "^15.6.0"
 
-eslint-plugin-scanjs-rules@>=0.1.4:
+eslint-plugin-scanjs-rules@>=0.1.4, eslint-plugin-scanjs-rules@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-scanjs-rules/-/eslint-plugin-scanjs-rules-0.2.1.tgz#a37403fde845df41277e03e5c2073f055d47942d"
   dependencies:


### PR DESCRIPTION
Adds eslint-plugin-scanjs-rules to the eslint-4 channel.

https://www.npmjs.com/package/eslint-plugin-scanjs-rules