### PR TITLE
Add eslint-plugin-es5 to whitelisted plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint-plugin-backbone": "^2.1.1",
     "eslint-plugin-drupal": "^0.3.1",
     "eslint-plugin-ember": "^4.5.0",
+    "eslint-plugin-es5": "^1.2.0",
     "eslint-plugin-flowtype": "^2.35.1",
     "eslint-plugin-html": "^3.2.2",
     "eslint-plugin-import": "^2.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1193,6 +1193,10 @@ eslint-plugin-ember@^4.5.0:
     require-folder-tree "^1.4.5"
     snake-case "^2.1.0"
 
+eslint-plugin-es5@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-es5/-/eslint-plugin-es5-1.2.0.tgz#22e1e7d5681b3a2f2588247bc9ca51dbfee6f6e9"
+
 eslint-plugin-flowtype@2.35.1:
   version "2.35.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.35.1.tgz#9ad98181b467a3645fbd2a8d430393cc17a4ea63"


### PR DESCRIPTION
Per [this comment](https://github.com/codeclimate/codeclimate-eslint/pull/371#issuecomment-367753528) on #371 this is a PR to get the eslint-plugin-es5 into the eslint-4 branch.