### PR TITLE
Bump eslint-plugin-security to 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "eslint-plugin-react-native": "^2.3.1",
     "eslint-plugin-rulesdir": "^0.1.0",
     "eslint-plugin-scanjs-rules": "^0.1.5",
-    "eslint-plugin-security": "^1.3.0",
+    "eslint-plugin-security": "^1.4.0",
     "eslint-plugin-sort-class-members": "^1.1.1",
     "eslint-plugin-sorting": "^0.3.0",
     "eslint-plugin-standard": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1423,9 +1423,15 @@ eslint-plugin-scanjs-rules@>=0.1.4, eslint-plugin-scanjs-rules@^0.1.5:
     babel-eslint ">=4.1.1"
     eslint ">=1.1"
 
-eslint-plugin-security@>=1.2.0, eslint-plugin-security@^1.3.0:
+eslint-plugin-security@>=1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-security/-/eslint-plugin-security-1.3.0.tgz#f106e2f6b9b81b757f8ee969d34456ef0e51dcea"
+  dependencies:
+    safe-regex "^1.1.0"
+
+eslint-plugin-security@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-security/-/eslint-plugin-security-1.4.0.tgz#d4f314484a80b1b613b8c8886e84f52efe1526c2"
   dependencies:
     safe-regex "^1.1.0"
 


### PR DESCRIPTION
- Bump ```eslint-plugin-security``` from ```1.3.0``` to ```1.4.0```
  - Fixes https://github.com/codeclimate/codeclimate-eslint/issues/378