### PR TITLE
Adding support for eslint-plugin-vue (eslint 4 channel)

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "eslint-plugin-security": "1.4.0",
     "eslint-plugin-sorting": "^0.3.0",
     "eslint-plugin-standard": "^3.0.1",
+    "eslint-plugin-vue": "^4.2.2",
     "eslint-plugin-xogroup": "^2.1.0",
     "glob": "^7.1.2",
     "prettier": "^1.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1415,6 +1415,12 @@ eslint-plugin-standard@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-standard/-/eslint-plugin-standard-3.0.1.tgz#34d0c915b45edc6f010393c7eef3823b08565cf2"
 
+eslint-plugin-vue@^4.2.2:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-vue/-/eslint-plugin-vue-4.3.0.tgz#478c6267269dbaa20f6e8b2cfae7a0ccc98c1d72"
+  dependencies:
+    vue-eslint-parser "^2.0.3"
+
 eslint-plugin-xogroup@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-xogroup/-/eslint-plugin-xogroup-2.1.0.tgz#11bc2b069b85b2ffa31376552b44a3f773b8e657"
@@ -3239,6 +3245,17 @@ vm-browserify@0.0.4:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-0.0.4.tgz#5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73"
   dependencies:
     indexof "0.0.1"
+
+vue-eslint-parser@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/vue-eslint-parser/-/vue-eslint-parser-2.0.3.tgz#c268c96c6d94cfe3d938a5f7593959b0ca3360d1"
+  dependencies:
+    debug "^3.1.0"
+    eslint-scope "^3.7.1"
+    eslint-visitor-keys "^1.0.0"
+    espree "^3.5.2"
+    esquery "^1.0.0"
+    lodash "^4.17.4"
 
 walker@1.x:
   version "1.0.7"


### PR DESCRIPTION
Currently `eslint-plugin-vue` exists in master (eslint 3) but codeclimate doesn't have this plugin for eslint 4. This PR adds the support.

It's related to https://github.com/codeclimate/codeclimate-eslint/issues/365