### PR TITLE
Add `eslint-config-will-robinson`

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "eslint-config-standard-jsx": "^4.0.2",
     "eslint-config-standard-react": "^5.0.0",
     "eslint-config-vue": "^2.0.2",
+    "eslint-config-will-robinson": "^1.1.2",
     "eslint-config-xo": "^0.19.0",
     "eslint-config-xo-react": "^0.14.0",
     "eslint-config-xo-space": "^0.17.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1010,6 +1010,10 @@ eslint-config-vue@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/eslint-config-vue/-/eslint-config-vue-2.0.2.tgz#a3ab1004899e49327a94c63e24d47a396b2f4848"
 
+eslint-config-will-robinson@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-config-will-robinson/-/eslint-config-will-robinson-1.1.2.tgz#6d811d8717ab1ff5db62e9f859927ea29a59e734"
+
 eslint-config-xo-react@^0.14.0:
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/eslint-config-xo-react/-/eslint-config-xo-react-0.14.0.tgz#eaa3ecc14d3860b495f64dfc19a8674d21a93d40"


### PR DESCRIPTION
Hi, I have a configuration package that I would like to be whitelisted.  Rather than copy and paste and synchronize my linting rules from project-to-project, which has become a maintenance burden, I’ve opted to centralize them [as a package](https://github.com/jacksonrayhamilton/eslint-config-will-robinson).

It would be great if you would whitelist my package so that my company’s configuration will not need to regress back copying and pasting in order to utilize your service for our JavaScript code.