### PR TITLE
upgrade eslint-plugin-react (7.7.0 -> 7.11.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "eslint-plugin-prettier": "^2.6.2",
     "eslint-plugin-promise": "^3.6.0",
     "eslint-plugin-ramda": "^2.4.0",
-    "eslint-plugin-react": "^7.7.0",
+    "eslint-plugin-react": "^7.11.0",
     "eslint-plugin-react-native": "^3.1.0",
     "eslint-plugin-security": "1.4.0",
     "eslint-plugin-sorting": "^0.3.0",


### PR DESCRIPTION
Tests were broken in `channel/eslint-4` branch due to PR #420 

```
8 passing (2s)
  4 failing

  1) eslint integration extends plugin loads the plugin and does not include repeated issues of not found rules:
     Error: /usr/local/node_modules/eslint-config-airbnb/rules/react.js:
	Configuration for rule "react/jsx-no-bind" is invalid:
	Value {"ignoreRefs":true,"allowArrowFunctions":true,"allowFunctions":false,"allowBind":false,"ignoreDOMComponents":true} should NOT have additional properties.

Referenced from: /usr/local/node_modules/eslint-config-airbnb/index.js
Referenced from: /usr/src/app/integration/extends_airbnb/eslintrc.json
      at validateRuleOptions (/usr/local/node_modules/eslint/lib/config/config-validator.js:119:19)
      at Object.keys.forEach.id (/usr/local/node_modules/eslint/lib/config/config-validator.js:162:9)
      at Array.forEach (<anonymous>)
      at validateRules (/usr/local/node_modules/eslint/lib/config/config-validator.js:161:30)
      at Object.validate (/usr/local/node_modules/eslint/lib/config/config-validator.js:239:5)
      at loadFromDisk (/usr/local/node_modules/eslint/lib/config/config-file.js:516:19)
      at load (/usr/local/node_modules/eslint/lib/config/config-file.js:559:20)
      at configExtends.reduceRight (/usr/local/node_modules/eslint/lib/config/config-file.js:425:36)
      at Array.reduceRight (<anonymous>)
      at applyExtends (/usr/local/node_modules/eslint/lib/config/config-file.js:403:26)
      at loadFromDisk (/usr/local/node_modules/eslint/lib/config/config-file.js:523:22)
      at load (/usr/local/node_modules/eslint/lib/config/config-file.js:559:20)
      at configExtends.reduceRight (/usr/local/node_modules/eslint/lib/config/config-file.js:425:36)
      at Array.reduceRight (<anonymous>)
      at applyExtends (/usr/local/node_modules/eslint/lib/config/config-file.js:403:26)
      at loadFromDisk (/usr/local/node_modules/eslint/lib/config/config-file.js:523:22)
      at Object.load (/usr/local/node_modules/eslint/lib/config/config-file.js:559:20)
      at Config.loadSpecificConfig (/usr/local/node_modules/eslint/lib/config.js:135:46)
      at new Config (/usr/local/node_modules/eslint/lib/config.js:101:14)
      at new CLIEngine (/usr/local/node_modules/eslint/lib/cli-engine.js:421:23)
      at Object.run (lib/eslint.js:234:9)
      at executeConfig (integration/eslint_test.js:13:19)
      at Context.<anonymous> (integration/eslint_test.js:49:7)
```

This is because `ignoreDOMComponents` was only added in `eslint-plugin-react` v7.11.0+: yannickcr/eslint-plugin-react@5709271