### PR TITLE
Add eslint-comments plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,12 @@ test: yarn.lock
 		--workdir /usr/src/app \
 		$(IMAGE_NAME) npm run $(NPM_TEST_TARGET)
 
+yarn.add:
+	docker run -ti --rm \
+		-v $(PWD):/usr/src/app \
+		--workdir /usr/src/app \
+		$(IMAGE_NAME) yarn add $(ARGS)
+
 citest:
 	docker run --rm \
 		--workdir /usr/src/app \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: image test citest integration yarn.lock
+.PHONY: image test citest integration yarn.lock yarn.add
 
 IMAGE_NAME ?= codeclimate/codeclimate-eslint
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ available in the container.
 * eslint-plugin-drupal
 * eslint-plugin-ember
 * eslint-plugin-es5
+* eslint-plugin-eslint-comments
 * eslint-plugin-flowtype
 * eslint-plugin-html
 * eslint-plugin-import

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "eslint-plugin-drupal": "^0.3.1",
     "eslint-plugin-ember": "^5.2.0",
     "eslint-plugin-es5": "^1.2.0",
+    "eslint-plugin-eslint-comments": "^3.0.1",
     "eslint-plugin-flowtype": "^3.0.0",
     "eslint-plugin-html": "^4.0.6",
     "eslint-plugin-import": "^2.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1710,6 +1710,13 @@ eslint-plugin-es@^1.3.1:
     eslint-utils "^1.3.0"
     regexpp "^2.0.0"
 
+eslint-plugin-eslint-comments@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.0.1.tgz#baafb713584c0de7ee588710720e580bcc28cfbb"
+  dependencies:
+    escape-string-regexp "^1.0.5"
+    ignore "^3.3.8"
+
 eslint-plugin-flowtype@2.35.1:
   version "2.35.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.35.1.tgz#9ad98181b467a3645fbd2a8d430393cc17a4ea63"
@@ -2704,7 +2711,7 @@ ignore-walk@^3.0.1:
   dependencies:
     minimatch "^3.0.4"
 
-ignore@^3.2.0:
+ignore@^3.2.0, ignore@^3.3.8:
   version "3.3.10"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
 


### PR DESCRIPTION
Workaround for https://github.com/codeclimate/codeclimate-eslint/issues/430

There were some changes in ESLint-5 way to load plugins that is being tricky to
patch to make the engine work with non-preexisting plugins.

This adds to the engine the plugin needed by the in the issue above.