### PR TITLE
add setting blocklist

### DIFF
--- a/lib/eslint-patch.js
+++ b/lib/eslint-patch.js
@@ -7,6 +7,7 @@ const ConfigFile = require("eslint/lib/config/config-file");
 
 const Config = require("eslint/lib/config");
 const RuleBlocklist = require("./rule_blocklist");
+const SettingBlocklist = require("./setting_blocklist");
 
 module.exports = function patch() {
   const skippedModules = [];
@@ -51,9 +52,11 @@ module.exports = function patch() {
   Config.prototype.getConfig = function(filePath) {
     const originalConfig = originalGetConfig.apply(this, [filePath]);
     const ruleBlocklist = new RuleBlocklist();
-
+    const settingBlocklist = new SettingBlocklist();
     return ruleBlocklist.filter(
-      originalConfig
+      settingBlocklist.filter(
+        originalConfig
+      )
     );
   };
 

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -11,6 +11,8 @@ const checks = require("./checks");
 const validateConfig = require("./validate_config");
 const computeFingerprint = require("./compute_fingerprint");
 const RuleBlocklist = require("./rule_blocklist");
+const SettingBlocklist = require("./setting_blocklist");
+
 const findConfigs = require("./config_finder");
 
 const CLIEngine = eslint.CLIEngine;
@@ -243,7 +245,8 @@ function run(console, runOptions) {
   let configs = findConfigs(options.configFile, analysisFiles);
 
   let report = [
-    RuleBlocklist.report(configs)
+    RuleBlocklist.report(configs),
+    SettingBlocklist.report(configs),
   ].reduce(function(a, b) { return a.concat([""]).concat(b); });
 
   for (const line of report) {

--- a/lib/setting_blocklist.js
+++ b/lib/setting_blocklist.js
@@ -1,0 +1,78 @@
+"use strict";
+
+const Config = require("eslint/lib/config")
+  , Linter = require("eslint/lib/linter")
+  , merge = require("eslint/lib/config/config-ops").merge;
+
+const blocklistedSettings = [
+  "import/resolver"
+];
+
+function filterSettings(settings) {
+  let report = [];
+
+  for (const name of blocklistedSettings) {
+    if (Reflect.has(settings, name)) {
+      delete settings[name];
+      report.push(`* ${name}`);
+    }
+  }
+  return report;
+}
+
+class SettingBlocklist {
+  constructor() {
+    this._report = [];
+  }
+
+  filter(originalConfig) {
+    if (typeof originalConfig === "undefined" || originalConfig === null) {
+      return {};
+    }
+
+    let config = merge({}, originalConfig);
+
+    this._report = [];
+
+    if (Reflect.has(config, "settings")) {
+      let report = filterSettings(config.settings);
+      this._report = this._report.concat(report);
+    }
+
+    return config;
+  }
+
+  get report() {
+    return [].concat(this._report);
+  }
+
+  static report(configs) {
+    const reports = configs.map(function(configFile) {
+      let report = [];
+
+      const blocklist = new SettingBlocklist();
+      const config = new Config({
+        configFile: configFile,
+        cwd: process.cwd()
+      },
+      new Linter());
+      blocklist.filter(config.specificConfig);
+
+      if (report.length > 0 || blocklist.report.length > 0) {
+        report = report.concat(blocklist.report);
+      }
+
+      return report;
+    }).filter(function(report) { return report.length > 0; });
+
+    if (reports.length === 0) {
+      return [];
+    } else {
+      return [["Ignoring the following settings that rely on module resolution:"]]
+        .concat(reports)
+        .reduce(function(a, b) { return a.concat([""]).concat(b); });
+    }
+  }
+}
+
+module.exports = SettingBlocklist;


### PR DESCRIPTION
i think this might solve #427 and #426 - since we're already disabling all of the `import/*` rules there's no reason to keep the `import/resolver` settings - this is what's causing these other modules to be instantiated. 

i added local specs but i don't know how to run integration specs inside of the engine/image so i haven't tested that yet. 