### PR TITLE
Fix badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Code Climate][badge]][repo]
 
 [badge]: https://codeclimate.com/github/codeclimate/codeclimate-eslint/badges/gpa.svg
-[repo]: https://codeclimate.com/repos/github/codeclimate-eslint
+[repo]: https://codeclimate.com/github/codeclimate/codeclimate-eslint
 
 `codeclimate-eslint` is a Code Climate engine that wraps [ESLint][]. You can run
 it on your command line using the Code Climate CLI, or on our hosted analysis


### PR DESCRIPTION
I noticed that the maintainability badge link was broken (404 "This page does not exist."). This pull request simply fixes it! :)