### PR TITLE
Update eslint-plugin-cypress to 2.11.1

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1161,10 +1161,11 @@ eslint-plugin-coffeescript@^1.0.0:
     source-map "^0.6.1"
 
 eslint-plugin-cypress@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-cypress/-/eslint-plugin-cypress-2.0.1.tgz#647e942cacbfd71b0f1a1ed6978472fbd475c60a"
+  version "2.11.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-cypress/-/eslint-plugin-cypress-2.11.1.tgz#a945e2774b88211e2c706a059d431e262b5c2862"
+  integrity sha512-MxMYoReSO5+IZMGgpBZHHSx64zYPSPTpXDwsgW7ChlJTF/sA+obqRbHplxD6sBStE+g4Mi0LCLkG4t9liu//mQ==
   dependencies:
-    globals "^11.0.1"
+    globals "^11.12.0"
 
 eslint-plugin-drupal@^0.3.1:
   version "0.3.1"
@@ -1797,9 +1798,10 @@ glob@7.1.1, glob@^7.0.0, glob@^7.0.3, glob@^7.0.6, glob@^7.1.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-globals@^11.0.1:
-  version "11.7.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-11.7.0.tgz#a583faa43055b1aca771914bf68258e2fc125673"
+globals@^11.12.0:
+  version "11.12.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
+  integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
 globals@^9.0.0, globals@^9.14.0:
   version "9.14.0"


### PR DESCRIPTION
Version 2.1.0 added a recommended setting to apply the recommended
rules. Updating this will allow users to use that in
their eslintrc. Currently analyze will throw an error when it
encounters this recommended option.

Upgraded via CONTRIBUTING.md commands using test instance 
and running against issue's inputs.

Closes #484 

- [Cypress plugin 2.1.0][2.1.0]
- [codeclimate-eslint yarn.lock][codeclimate-eslint]

[2.1.0]: https://github.com/cypress-io/eslint-plugin-cypress/releases/tag/v2.1.0
[codeclimate-eslint]: https://github.com/codeclimate/codeclimate-eslint/blob/0612a739c4c32e096f8049a86ace48b5c4894afc/yarn.lock#L1164