### PR TITLE
Add you dont need lodash plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "eslint-plugin-wordpress": "^0.1.0",
     "eslint-plugin-xogroup": "^1.2.0",
     "eslint-plugin-xss": "^0.1.8",
+    "eslint-plugin-you-dont-need-lodash-underscore": "^6.10.0",
     "glob": "^7.0.6",
     "prettier": "^1.2.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1532,6 +1532,13 @@ eslint-plugin-xss@^0.1.8:
   dependencies:
     requireindex "~1.1.0"
 
+eslint-plugin-you-dont-need-lodash-underscore@^6.10.0:
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-you-dont-need-lodash-underscore/-/eslint-plugin-you-dont-need-lodash-underscore-6.10.0.tgz#63df0785ee1a07365ef77db907692f1ac928e000"
+  integrity sha512-Zu1KbHiWKf+alVvT+kFX2M5HW1gmtnkfF1l2cjmFozMnG0gbGgXo8oqK7lwk+ygeOXDmVfOyijqBd7SUub9AEQ==
+  dependencies:
+    kebab-case "^1.0.0"
+
 eslint-restricted-globals@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz#35f0d5cbc64c2e3ed62e93b4b1a7af05ba7ed4d7"
@@ -2191,6 +2198,11 @@ jsx-ast-utils@^2.0.0, jsx-ast-utils@^2.0.1:
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz#e801b1b39985e20fffc87b40e3748080e2dcac7f"
   dependencies:
     array-includes "^3.0.3"
+
+kebab-case@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/kebab-case/-/kebab-case-1.0.0.tgz#3f9e4990adcad0c686c0e701f7645868f75f91eb"
+  integrity sha1-P55JkK3K0MaGwOcB92RYaPdfkes=
 
 leven@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
This plugin helps codebases migrate from lodash/underscore to ES6+ based
methods available natively on the browser. Currently it has about 25k
downloads per week. We are currently using it but are blocked from
adding it to the CodeClimate build due to it being missing here.

https://libraries.io/npm/eslint-plugin-you-dont-need-lodash-underscore
https://www.npmjs.com/package/eslint-plugin-you-dont-need-lodash-underscore

Tested against eslintrc.js

```
module.exports = {
  extends: [
    "plugin:you-dont-need-lodash-underscore/compatible",
  ]
}
```