### PR TITLE
QUAPL-45: Update typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "eslint-plugin-xogroup": "^2.3.1",
     "glob": "^7.1.4",
     "prettier": "^1.17.1",
-    "typescript": "3.4.4",
+    "typescript": "3.9.7",
     "webpack": "^4.32.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4593,9 +4593,10 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@3.4.4:
-  version "3.4.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.4.tgz#aac4a08abecab8091a75f10842ffa0631818f785"
+typescript@3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 union-value@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Reproduced issue reported in https://codeclimate.atlassian.net/browse/QUAPL-45 and checked that this update effectively fixes it.
I also did the same update for the eslint-7 channel we added recently https://github.com/codeclimate/codeclimate-eslint/pull/494