### PR TITLE
upgrade eslint-plugin-ramda to 2.5.1 (ESLint 6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "eslint-plugin-node": "^7.0.1",
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-promise": "^4.1.1",
-    "eslint-plugin-ramda": "^2.4.0",
+    "eslint-plugin-ramda": "^2.5.1",
     "eslint-plugin-react": "^7.13.0",
     "eslint-plugin-react-hooks": "^1.6.0",
     "eslint-plugin-react-native": "^3.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1846,9 +1846,10 @@ eslint-plugin-promise@^4.1.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz#845fd8b2260ad8f82564c1222fce44ad71d9418a"
 
-eslint-plugin-ramda@^2.4.0:
+eslint-plugin-ramda@^2.5.1:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-ramda/-/eslint-plugin-ramda-2.5.1.tgz#36c2592300c383471aaac1ba26e9fca6f37a11b2"
+  integrity sha512-1Uuyl5hMiyBNsn1F0Px0q8hGX95HC6CAzaEBeKngwixXwsbw+j98U7fatxDME8lUKyLPXuO5Ulon2QOcwVDrxw==
   dependencies:
     create-eslint-index "^1.0.0"
     ramda "0.25.0"


### PR DESCRIPTION
Upgrade eslint-plugin-ramda to 2.5.1.

Address a request made in the CLI repository https://github.com/codeclimate/codeclimate/issues/819. There wasn't a specific ESLint version requested so starting with ESLint 6.