### PR TITLE
QUA-146: Fix no rules configured warning

### DIFF
--- a/integration/eslint_test.js
+++ b/integration/eslint_test.js
@@ -43,17 +43,6 @@ describe("eslint integration", function() {
   })
 
   describe("validating config", function() {
-    it("warns about empty config but not raise error", function() {
-      function executeEmptyConfig() {
-        executeConfig("empty_config/config.json")
-      }
-
-      expect(executeEmptyConfig).to.not.throw()
-      expect(consoleMock.outputErr).to.include(
-        "No rules are configured. Make sure you have added a config file with rules enabled."
-      )
-    })
-
     it("raise on file not found", function() {
       function executeNoLintrc() {
         executeConfig("no_lintrc/config.json")

--- a/lib/eslint6-patch.js
+++ b/lib/eslint6-patch.js
@@ -34,21 +34,6 @@ module.exports = function patch() {
     }
   }
 
-  function configWithRules(config) {
-    if (config.rules) {
-      return config
-    }
-
-    console.error(
-      "No rules are configured. Make sure you have added a config file with rules enabled."
-    )
-    console.error(
-      "See our documentation at https://docs.codeclimate.com/docs/eslint for more information."
-    )
-
-    return false
-  }
-
   function patchPluginLoading() {
     const methods = [
       "_loadExtendedPluginConfig",
@@ -84,21 +69,13 @@ module.exports = function patch() {
     })
   }
 
-  function patchConfigs() {
-    const originalLoadConfigData = ConfigArrayFactory.prototype._loadConfigData
-    ConfigArrayFactory.prototype._loadConfigData = function _loadConfigData() {
-      const results = originalLoadConfigData.apply(this, arguments)
-      return [...results].filter(configWithRules)
-    }
-  }
-
   function patchConfigArray() {
     const orig = ConfigArray.prototype.extractConfig
     ConfigArray.prototype.extractConfig = function extractConfig() {
       const config = orig.apply(this, arguments)
 
       RULES_BLOCKLIST.forEach((ruleName) => {
-        if (config.rules[ruleName] !== "off") {
+        if (config.rules && config.rules[ruleName] !== "off") {
           config.rules[ruleName] = "off"
           disabledRules.add(ruleName)
         }
@@ -116,7 +93,6 @@ module.exports = function patch() {
   }
 
   patchPluginLoading()
-  patchConfigs()
   patchConfigArray()
 
   return {

--- a/lib/eslint6-patch.js
+++ b/lib/eslint6-patch.js
@@ -74,19 +74,23 @@ module.exports = function patch() {
     ConfigArray.prototype.extractConfig = function extractConfig() {
       const config = orig.apply(this, arguments)
 
-      RULES_BLOCKLIST.forEach((ruleName) => {
-        if (config.rules && config.rules[ruleName] !== "off") {
-          config.rules[ruleName] = "off"
-          disabledRules.add(ruleName)
-        }
-      })
+      if (config.rules) {
+        RULES_BLOCKLIST.forEach((ruleName) => {
+          if (config.rules[ruleName] !== "off") {
+            config.rules[ruleName] = "off"
+            disabledRules.add(ruleName)
+          }
+        })
+      }
 
-      SETTINGS_BLOCKLIST.forEach((settingName) => {
-        if (config.settings && config.settings[settingName]) {
-          delete config.settings[settingName]
-          removedSettings.add(settingName)
-        }
-      })
+      if (config.settings) {
+        SETTINGS_BLOCKLIST.forEach((settingName) => {
+          if (config.settings[settingName]) {
+            delete config.settings[settingName]
+            removedSettings.add(settingName)
+          }
+        })
+      }
 
       return config
     }

--- a/test/eslint6-patch_test.js
+++ b/test/eslint6-patch_test.js
@@ -2,6 +2,7 @@ const expect = require("chai").expect
 const sinon = require("sinon")
 
 const { ConfigArrayFactory } = require("eslint/lib/cli-engine/config-array-factory")
+const { ConfigArray } = require("eslint/lib/cli-engine/config-array")
 
 const eslintPatch = require("../lib/eslint6-patch")
 
@@ -11,11 +12,11 @@ const eslintPatch = require("../lib/eslint6-patch")
  */
 describe("eslint6-patch", function() {
   describe("patch", function() {
-    let originalLoadPlugin, originalLoadConfigData
+    let originalLoadPlugin, originalExtractConfig
 
     before(function() {
       originalLoadPlugin = ConfigArrayFactory.prototype._loadPlugin
-      originalLoadConfigData = ConfigArrayFactory.prototype._loadConfigData
+      originalExtractConfig = ConfigArray.prototype.extractConfig
     })
 
     it("intercepts plugin loading", function() {
@@ -28,9 +29,9 @@ describe("eslint6-patch", function() {
 
     it("intercepts rule configs", function() {
       eslintPatch()
-      expect(originalLoadConfigData).to.not.equal(
-        ConfigArrayFactory.prototype._loadConfigData,
-        "ConfigArrayFactory._loadConfigData is not patched"
+      expect(originalExtractConfig).to.not.equal(
+        ConfigArray.prototype.extractConfig,
+        "ConfigArray.prototype.extractConfig is not patched"
       )
     })
   })


### PR DESCRIPTION
Report: https://codeclimate.atlassian.net/browse/QUA-146

**Root causes**
* In `channel/eslint-5` we started using [typescript-eslint](https://github.com/typescript-eslint/typescript-eslint).
* `typescript-eslint` adds some pre-built configuration files that can be use in the `.eslintrc.*` config file to extend configuration.
* In particular, two files trigger the `No rules configured warning`: [this one](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/src/configs/eslint-recommended.ts) and [this one](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/src/configs/base.ts).
* The first one has rules defined but it's in `overrides`, which the `CLIEngine` we are using does not support (See supported features [here](https://eslint.org/docs/developer-guide/nodejs-api#cliengine)). **Important:** Though `CLIEngine` does not support the `overrides` feature for what we want to do (patching it), those rules defined in that file are being taken into account during analyses. I tested it with the [prefer-rest-params rule](https://eslint.org/docs/rules/prefer-rest-params) that's not on by default with just the eslint rules.
* The second file simply does not have rules because of the way `typescript-eslint` organizes its files.

**Proposed changes**
1. Stop warning for empty config files to avoid confusion (that's the change in this PR). The disadvantage is that we won't be warning any files, but also the warning is not helping right now as it's always being throw.
2. Throw the warning with the file path and disclaimers saying that if the file comes from an external source or uses overrides you should probably do nothing --> This would be relatively easy to implement, though it may be noisy and users may have a similar estructure where they have config files without rules and that doesn't necessarily mean there's a problem.

**Next steps**
* After settling on a possible solution, applying it to `channel/eslint-5`, `channel/eslint-6` and `channel/eslint-7`.
* `CLIEngine` is deprecated in favor of using `ESLint7` class, so maybe we will have to plan if we want to update the code.
