### PR TITLE
Support @hapi/eslint-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@babel/core": "^7.12.13",
     "@babel/eslint-parser": "^7.12.13",
     "@babel/plugin-transform-runtime": "^7.13.10",
+    "@hapi/eslint-plugin": "^5.0.0",
     "@typescript-eslint/eslint-plugin": "^4.9.0",
     "@typescript-eslint/parser": "^4.9.0",
     "babel-eslint": "^10.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -360,6 +360,11 @@
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/@ember-data/rfc395-data/-/rfc395-data-0.0.4.tgz#ecb86efdf5d7733a76ff14ea651a1b0ed1f8a843"
 
+"@hapi/eslint-plugin@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@hapi/eslint-plugin/-/eslint-plugin-5.0.0.tgz#936b91d6c50de5011d6b918c041804e2c255d9d4"
+  integrity sha512-a3K7cVhxhcN3NJv+UCFeOS8RO+mFtnpgbtkDIPplOdBQoYEuAUCePooZKJuYu07N5z/QjmsSQz83Xx/hHlfJDA==
+
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"


### PR DESCRIPTION
hapi have moved their config to `@hapi/eslint-plugin`.

Add the new package, and keep the old config for backward compatibility.

Refs:
- https://github.com/hapijs/eslint-plugin/pull/20
- https://github.com/hapijs/eslint-plugin/issues/21