### PR TITLE
Add eslint-plugin-vue-split-by-script-lang

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ available in the container.
 * eslint-plugin-standard
 * eslint-plugin-testing-library
 * eslint-plugin-vue
+* eslint-plugin-vue-split-by-script-lang
 * eslint-plugin-xogroup
 
 ##### Plugins Major Version Bump

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "eslint-plugin-testing-library": "^4.2.0",
     "eslint-plugin-vue": "^7.7.0",
     "eslint-plugin-vue-a11y": "^0.0.28",
+    "eslint-plugin-vue-split-by-script-lang": "^1.0.2",
     "eslint-plugin-xogroup": "^2.3.1",
     "glob": "^7.1.4",
     "next": "^11.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1448,7 +1448,7 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.10.3.tgz#7a8f2838603ea314d1d22bb3171d899e15c57bd5"
   integrity sha512-ho3Ruq+fFnBrZhUYI46n/bV2GjwzSkwuT4dTf0GkuNFmnb8nq4ny2z9JEVemFi6bdEJanHLlYfy9c6FN9B9McQ==
 
-"@typescript-eslint/eslint-plugin@^4.9.0":
+"@typescript-eslint/eslint-plugin@^4.33.0":
   version "4.33.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz#c24dc7c8069c7706bc40d99f6fa87edcb2005276"
   integrity sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==
@@ -1496,6 +1496,16 @@
     "@typescript-eslint/typescript-estree" "4.29.3"
     debug "^4.3.1"
 
+"@typescript-eslint/parser@^4.33.0":
+  version "4.33.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.33.0.tgz#dfe797570d9694e560528d18eecad86c8c744899"
+  integrity sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==
+  dependencies:
+    "@typescript-eslint/scope-manager" "4.33.0"
+    "@typescript-eslint/types" "4.33.0"
+    "@typescript-eslint/typescript-estree" "4.33.0"
+    debug "^4.3.1"
+
 "@typescript-eslint/parser@^4.4.1":
   version "4.28.5"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.28.5.tgz#9c971668f86d1b5c552266c47788a87488a47d1c"
@@ -1504,16 +1514,6 @@
     "@typescript-eslint/scope-manager" "4.28.5"
     "@typescript-eslint/types" "4.28.5"
     "@typescript-eslint/typescript-estree" "4.28.5"
-    debug "^4.3.1"
-
-"@typescript-eslint/parser@^4.9.0":
-  version "4.33.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.33.0.tgz#dfe797570d9694e560528d18eecad86c8c744899"
-  integrity sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==
-  dependencies:
-    "@typescript-eslint/scope-manager" "4.33.0"
-    "@typescript-eslint/types" "4.33.0"
-    "@typescript-eslint/typescript-estree" "4.33.0"
     debug "^4.3.1"
 
 "@typescript-eslint/scope-manager@4.22.1":
@@ -4164,6 +4164,11 @@ eslint-plugin-vue-a11y@^0.0.28:
     eslint-plugin-vue "^4.4.0"
     jsx-ast-utils "^2.0.1"
     vue-eslint-parser "^2.0.3"
+
+eslint-plugin-vue-split-by-script-lang@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-vue-split-by-script-lang/-/eslint-plugin-vue-split-by-script-lang-1.0.2.tgz#eeba9dee1c12ce5cd5422e9e1fdc97e1f4e32f83"
+  integrity sha512-bW+WdhaNy5pm6gyxhtBOzOuBVWETwvdOiGWsrairUnk6ZT4xS9nrgEJbWntmGfOREUcJRiXdgMVl8xRRiBvxUA==
 
 eslint-plugin-vue@^4.4.0:
   version "4.7.1"


### PR DESCRIPTION
Adds the eslint plugin [eslint-plugin-vue-split-by-script-lang](https://www.npmjs.com/package/eslint-plugin-vue-split-by-script-lang).

We need this plugin to be able to lint a vue codebase with both typescript and javascript vue files. Without the plugin, it's not possible to add typescript rules just for `.vue` files that contain typescript.

I followed the steps in CONTRIBUTING.md to add the package and test the changes.