### PR TITLE
QUA-460: fix calculateConfigForFile returning a Promise

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -56,7 +56,7 @@ async function run(console, runOptions) {
     return content + "Source: http://eslint.org/docs/rules/\n"
   }
 
-  function buildIssueJson(message, path) {
+  async function buildIssueJson(message, path) {
     // ESLint doesn't emit a ruleId in the
     // case of a fatal error (such as an invalid
     // token)
@@ -88,7 +88,7 @@ async function run(console, runOptions) {
           },
         },
       },
-      remediation_points: checks.remediationPoints(checkName, message, cli.calculateConfigForFile(path)),
+      remediation_points: checks.remediationPoints(checkName, message, await cli.calculateConfigForFile(path)),
     }
 
     var fingerprint = computeFingerprint(path, checkName, message.message)
@@ -201,16 +201,16 @@ async function run(console, runOptions) {
         batchReport = await cli.lintFiles(batchFiles)
       })
 
-      runWithTiming("report-batch" + batchNum, function() {
+      await runWithTimingAsync("report-batch" + batchNum, async function() {
         batchReport.forEach(function(result) {
           var path = result.filePath.replace(/^\/code\//, "")
 
-          result.messages.forEach(function(message) {
+          result.messages.forEach(async function(message) {
             if (ignoreWarnings && message.severity === ESLINT_WARNING_SEVERITY) {
               return
             }
 
-            var readableJsonStream = buildIssueJson(message, path)
+            var readableJsonStream = await buildIssueJson(message, path)
             var output = ""
             readableJsonStream.on('data', (chunk) => {
               output = output + `${JSON.stringify(chunk)}`


### PR DESCRIPTION
This PR fixes the error caused by the `calculateConfigForFile` method returning a Promise instead of an Object. When running ESLint, this error would come up:

```
/usr/src/app/lib/checks.js:30
   return eslintConfig.rules[ruleId][1];
                            ^

TypeError: Cannot read properties of undefined (reading 'max-len')
    at metricThreshold (/usr/src/app/lib/checks.js:30:29)
    at Object.remediationPoints (/usr/src/app/lib/checks.js:39:21)
    at buildIssueJson (/usr/src/app/lib/eslint.js:91:34)
    at /usr/src/app/lib/eslint.js:213:38
    at Array.forEach (<anonymous>)
    at /usr/src/app/lib/eslint.js:208:27
    at Array.forEach (<anonymous>)
    at /usr/src/app/lib/eslint.js:205:21
    at runWithTiming (/usr/src/app/lib/eslint.js:38:20)
    at analyzeFiles (/usr/src/app/lib/eslint.js:204:7)
```

Potentially, this could also fix the failures to parse some JSON messages reported in https://codeclimate.atlassian.net/browse/QUA-460 and https://github.com/codeclimate/codeclimate/pull/1040#issuecomment-1119804335