### PR TITLE
QUA-958: Push images to Dockerhub instead of GCR (eslint-1)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,13 +25,12 @@ jobs:
               circleci step halt
             fi
       - run: make image
-      - run: echo "$GCR_JSON_KEY" | docker login -u _json_key --password-stdin us.gcr.io
+      - run: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
       - run:
-          name: Push image to GCR
+          name: Push image to Dockerhub
           command: |
-            docker tag $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME \
-              us.gcr.io/code-climate/codeclimate-eslint:b$CIRCLE_BUILD_NUM
-            docker push us.gcr.io/code-climate/codeclimate-eslint:b$CIRCLE_BUILD_NUM
+            make release RELEASE_TAG="b$CIRCLE_BUILD_NUM"
+            make release RELEASE_TAG="$(echo $CIRCLE_BRANCH | grep -oP 'channel/\K[\w\-]+')"
 
 workflows:
   version: 2
@@ -39,6 +38,7 @@ workflows:
     jobs:
       - test
       - release_images:
+          context: Quality
           requires:
             - test
           filters:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 .PHONY: image test citest release
 
 IMAGE_NAME ?= codeclimate/codeclimate-eslint
+RELEASE_REGISTRY ?= codeclimate
+RELEASE_TAG ?= latest
 
 image:
 	docker build --rm -t $(IMAGE_NAME) .

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: image test citest
+.PHONY: image test citest release
 
 IMAGE_NAME ?= codeclimate/codeclimate-eslint
 
@@ -10,3 +10,7 @@ test: image
 
 citest:
 	docker run --rm $(IMAGE_NAME) sh -c "cd /usr/src/app && npm run test"
+
+release:
+	docker tag $(IMAGE_NAME) $(RELEASE_REGISTRY)/codeclimate-eslint:$(RELEASE_TAG)
+	docker push $(RELEASE_REGISTRY)/codeclimate-eslint:$(RELEASE_TAG)

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,10 @@
 
 IMAGE_NAME ?= codeclimate/codeclimate-eslint
 RELEASE_REGISTRY ?= codeclimate
-RELEASE_TAG ?= latest
+
+ifndef RELEASE_TAG
+override RELEASE_TAG = latest
+endif
 
 image:
 	docker build --rm -t $(IMAGE_NAME) .


### PR DESCRIPTION
Deprecate pushing of the image to GCR in favor of pushing to Dockerhub.