### PR TITLE
add `eslint-plugin-sonarjs` to eslint 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "eslint-plugin-react-hooks": "^1.6.0",
     "eslint-plugin-react-native": "^3.7.0",
     "eslint-plugin-security": "1.4.0",
+    "eslint-plugin-sonarjs": "^0.19.0",
     "eslint-plugin-sorting": "^0.3.0",
     "eslint-plugin-standard": "^4.0.0",
     "eslint-plugin-vue": "^5.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1923,6 +1923,11 @@ eslint-plugin-security@1.4.0, eslint-plugin-security@>=1.2.0:
   dependencies:
     safe-regex "^1.1.0"
 
+eslint-plugin-sonarjs@^0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-0.19.0.tgz#6654bc1c6d24c2183891b8bfe1175004dbba1e3c"
+  integrity sha512-6+s5oNk5TFtVlbRxqZN7FIGmjdPCYQKaTzFPmqieCmsU1kBYDzndTeQav0xtQNwZJWu5awWfTGe8Srq9xFOGnw==
+
 eslint-plugin-sorting@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-sorting/-/eslint-plugin-sorting-0.3.0.tgz#acf43ca88f34b42ba3d0f6bf0e0c50485a20f60d"


### PR DESCRIPTION
This adds in the `eslint-plugin-sonarjs` which should fix issues with repos that use `eslint-5` as a channel who use this plugin in analysis.